### PR TITLE
Add tests and fix factory methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,6 @@ install:
 
 script:
   - docker-compose up -d
+  # Wait 10s to make sure docker-compose has properly spun up speckle server
+  - sleep 10s
   - python -m pytest --cov=speckle tests/ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+
+python:
+  - '3.6'
+
+services:
+  - docker
+
+env: 
+  global:
+    - DOCKER_VERSION=1.10.1-0~trusty
+    - DOCKER_COMPOSE_VERSION=1.6.0
+
+before_install:
+  - apt-cache madison docker-engine
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
+  - sudo rm -f /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - pip install -r requirements.txt
+  - pip install pytest pytest-cov
+
+script:
+  - docker-compose up -d
+  - python -m pytest --cov=speckle tests/ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ services:
 
 env: 
   global:
-    - DOCKER_COMPOSE_VERSION=1.6.0
+    - DOCKER_COMPOSE_VERSION=1.24.0
 
 before_install:
-  - apt-cache madison docker-engine
-  - sudo rm -f /usr/local/bin/docker-compose
+  - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+
+install:
   - pip install -r requirements.txt
   - pip install pytest pytest-cov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,10 @@ services:
 
 env: 
   global:
-    - DOCKER_VERSION=1.10.1-0~trusty
     - DOCKER_COMPOSE_VERSION=1.6.0
 
 before_install:
   - apt-cache madison docker-engine
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
   - sudo rm -f /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3'
+services:
+  speckle:
+    image: speckle/speckleserver:latest
+    ports:
+      - '3000:3000'
+    networks:
+      - webnet
+    depends_on:
+      - redis
+      - mongo
+    environment:
+      - SERVER_NAME=Docker Speckle Server
+      - SESSION_SECRET=helloworld
+      - REQ_SIZE=16mb
+      - INDENT_RESPONSES=false
+      - MONGODB_URI=mongodb://mongo:27017/speckle_docker
+      - REDIS_URL=redis://redis:6379
+      - EXPOSE_EMAILS=false
+      - PUBLIC_STREAMS=true
+      - PLUGIN_DIRS="./node_modules/@speckle,./plugins"
+    links:
+      - redis
+      - mongo
+  mongo:
+    image: mongo:latest
+    ports:
+      - '27017:27017'
+    networks:
+      - webnet
+  redis:
+    image: redis:alpine
+    ports:
+      - '6379:6379'
+    networks:
+      - webnet
+networks:
+  webnet:

--- a/speckle/resources/accounts.py
+++ b/speckle/resources/accounts.py
@@ -4,23 +4,25 @@ from speckle.base.resource import ResourceBase
 
 
 NAME = 'accounts'
-METHODS = ['get', 'delete']
+METHODS = ['get', 'get_profile', 'update_profile', 'set_role', 'search']
 
 
-class UserSearch(BaseModel):
-    name: Optional[str] = None
-    surname: Optional[str] = None
-    company: Optional[str] = None
+class User(BaseModel):
+    id: Optional[str]
+    name: Optional[str]
+    surname: Optional[str]
+    company: Optional[str]
+    avatar: Optional[str]
+    role: Optional[str]
 
-class User(UserSearch):
-    avatar: Optional[str] = None
-
-class Role(BaseModel):
-    role: str
+    class Config:
+        fields = {'id': '_id'}
 
 class Resource(ResourceBase):
-    def __init__(self, session, basepath):
-        super().__init__(session, basepath, NAME, METHODS)
+    def __init__(self, session, basepath, me):
+        super().__init__(session, basepath, me, NAME, METHODS)
+
+        # self.schema = User
 
         self.method_dict.update({
             'get_profile': {
@@ -43,7 +45,8 @@ class Resource(ResourceBase):
     def update_profile(self, data):
         return self.make_request('update_profile', '/', data)
 
-    def set_role(self, id, data):
+    def set_role(self, id, role):
+        data = {'role': role}
         return self.make_request('set_role', '/' + id, data)
 
     def search(self, data):

--- a/speckle/resources/api_clients.py
+++ b/speckle/resources/api_clients.py
@@ -1,8 +1,9 @@
 import uuid
 from speckle.base.resource import ResourceBase
 from pydantic import BaseModel, UUID4, validator
-from typing import List, Optional
+from typing import List, Optional, Union
 from speckle.base.resource import ResourceBase, ResourceBaseSchema
+from speckle.resources.accounts import User
 from enum import Enum
 
 NAME = 'clients'
@@ -11,26 +12,28 @@ METHODS = ['list', 'create', 'get', 'update',
 
 
 class RoleEnum(str, Enum):
-    Receiver: 'Receiver'
-    Sender: 'Sender'
-    Hybrid: 'Hybrid'
+    receiver: 'Receiver'
+    sender: 'Sender'
+    hybrid: 'Hybrid'
 
 
-class Client(ResourceBaseSchema):
-    role: Optional[RoleEnum]
+class ApiClient(ResourceBaseSchema):
+    # role: Optional[RoleEnum] = RoleEnum.receiver
+    role: Optional[str]
     documentName: Optional[str]
     documentType: Optional[str]
     documentLocation: Optional[str]
-    documentGuid: Optional[UUID4]
+    documentGuid: Optional[str]
     streamId: Optional[str]
     online: Optional[bool]
+    owner: Optional[Union[User, str]]
 
     @validator('documentGuid', pre=True, always=True)
     def set_guid(cls, v):
-        return v or uuid.uuid4()
+        return v or str(uuid.uuid4())
 
 class Resource(ResourceBase):
-    def __init__(self, session, basepath):
-        super().__init__(session, basepath, NAME, METHODS)
+    def __init__(self, session, basepath, me):
+        super().__init__(session, basepath, me, NAME, METHODS)
 
-        self.schema = Client
+        self.schema = ApiClient

--- a/speckle/resources/comments.py
+++ b/speckle/resources/comments.py
@@ -3,14 +3,23 @@ from typing import List, Optional
 
 
 NAME = 'comments'
-METHODS = ['list', 'create', 'get', 'update',
+METHODS = ['list', 'get', 'update', 'assigned',
            'delete', 'comment_get', 'comment_create']
 
 
 
 
 class Resource(ResourceBase):
-    def __init__(self, session, basepath):
-        super().__init__(session, basepath, NAME, METHODS)
+    def __init__(self, session, basepath, me):
+        super().__init__(session, basepath, me, NAME, METHODS)
 
         self.schema = self.comment_schema
+
+        self.method_dict.update({
+            'assigned': {
+                    'method': 'GET'
+                }
+        })
+
+    def assigned(self):
+        return self.make_request('assigned', '/assigned')

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from speckle.base.resource import ResourceBase, ResourceBaseSchema
 
 NAME = 'objects'
-METHODS = ['list', 'create', 'get', 'update',
+METHODS = ['list', 'get', 'update',
            'delete', 'comment_get', 'comment_create']
 
 
@@ -35,8 +35,8 @@ class SpeckleObject(ResourceBaseSchema):
 
 
 class Resource(ResourceBase):
-    def __init__(self, session, basepath):
-        super().__init__(session, basepath, NAME, METHODS)
+    def __init__(self, session, basepath, me):
+        super().__init__(session, basepath, me, NAME, METHODS)
 
         self.method_dict.update({
             'get_bulk': {

--- a/speckle/resources/projects.py
+++ b/speckle/resources/projects.py
@@ -4,25 +4,40 @@ from typing import List, Optional
 from speckle.base.resource import ResourceBase, ResourceBaseSchema
 
 NAME = 'projects'
-METHODS = ['list', 'create', 'get', 'update', 'delete', 'comment_get', 'comment_create']
+METHODS = [
+    'list', 'create', 'get', 'update', 'delete',
+    'comment_get', 'comment_create', 'add_stream',
+    'add_user', 'remove_user', 'remove_stream',
+    'upgrade_user', 'downgrade_user'
+    ]
 
+class Permissions(BaseModel):
+    canRead: Optional[List[str]]
+    canWrite: Optional[List[str]]
 
 class Project(ResourceBaseSchema):
     name: Optional[str]
     description: Optional[str]
     tags: List[str] = []
     streams: List[str] = []
+    permissions: Optional[Permissions]
 
 
 class Resource(ResourceBase):
-    def __init__(self, session, basepath):
-        super().__init__(session, basepath, NAME, METHODS)
+    def __init__(self, session, basepath, me):
+        super().__init__(session, basepath, me, NAME, METHODS)
 
         self.method_dict.update({
             'add_stream': {
                 'method': 'PUT'
             },
             'remove_stream': {
+                'method': 'DELETE'
+            },
+            'add_user': {
+                'method': 'PUT'
+            },
+            'remove_user': {
                 'method': 'DELETE'
             },
             'upgrade_user': {
@@ -40,7 +55,7 @@ class Resource(ResourceBase):
         return self.make_request('add_stream', '/' + id + '/addstream/' + stream_id)
 
     def remove_stream(self, id, stream_id):
-        return self.make_request('remove_stream', '/' + id + '/removestream' + stream_id)
+        return self.make_request('remove_stream', '/' + id + '/removestream/' + stream_id)
     
     def add_user(self, id, user_id):
         return self.make_request('add_user', '/' + id + '/adduser/' + user_id)
@@ -52,4 +67,4 @@ class Resource(ResourceBase):
         return self.make_request('upgrade_user', '/' + id + '/upgradeuser/' + user_id)
 
     def downgrade_user(self, id, user_id):
-        return self.make_request('downgrade_user', '/' + id + '/downgradeuser' + user_id)
+        return self.make_request('downgrade_user', '/' + id + '/downgradeuser/' + user_id)

--- a/speckle/resources/streams.py
+++ b/speckle/resources/streams.py
@@ -3,10 +3,12 @@ from pydantic import BaseModel, UUID4, validator, Schema
 from typing import List, Optional
 from speckle.base.resource import ResourceBase, ResourceBaseSchema
 from speckle.resources.objects import SpeckleObject
+from speckle.resources.api_clients import ApiClient
 
 NAME = 'streams'
 METHODS = ['list', 'create', 'get', 'update',
-           'delete', 'comment_get', 'comment_create']
+           'delete', 'comment_get', 'comment_create',
+           'clone', 'diff', 'list_objects', 'list_clients']
 
 
 class LayerProperties(BaseModel):
@@ -21,7 +23,7 @@ class LayerProperties(BaseModel):
 
 
 class Layer(BaseModel):
-    guid: UUID4
+    guid: str
     name: str = 'New Layer'
     orderIndex: int = 0
     startIndex: int = 0
@@ -31,21 +33,25 @@ class Layer(BaseModel):
 
     @validator('guid', pre=True, always=True)
     def set_guid(cls, v):
-        return v or uuid.uuid4()
+        return v or str(uuid.uuid4())
 
 
 class Stream(ResourceBaseSchema):
+    streamId: Optional[str]
     name: Optional[str]
     description: Optional[str]
     tags: List[str] = []
     commitMessage: str  = 'Modified stream'
     objects: List[SpeckleObject] = []
     layers: List[Layer] = []
+    parent: Optional[str]
+    children: List[str] = []
+
 
 
 class Resource(ResourceBase):
-    def __init__(self, session, basepath):
-        super().__init__(session, basepath, NAME, METHODS)
+    def __init__(self, session, basepath, me):
+        super().__init__(session, basepath, me, NAME, METHODS)
 
         self.method_dict.update({
             'clone': {
@@ -65,17 +71,20 @@ class Resource(ResourceBase):
         self.schema = Stream
 
 
-    def clone(self, id):
-        return self.make_request('clone', '/' + id + '/clone')
+    def clone(self, id, name=None):
+        response = self.make_request('clone', '/' + id + '/clone', {'name': name})
+        clone = self._parse_response(response['clone'])
+        parent = self._parse_response(response['parent'])
+        return clone, parent
 
     def diff(self, id, other_id):
         return self.make_request('diff', '/' + id + '/diff/' + other_id)
 
     def list_objects(self, id):
-        return self.make_request('list_objects', '/' + id + '/objects')
+        return self.make_request('list_objects', '/' + id + '/objects', schema=SpeckleObject)
 
     def list_clients(self, id):
-        return self.make_request('list_clients', '/' + id + '/clients')
+        return self.make_request('list_clients', '/' + id + '/clients', schema=ApiClient)
 
     def list(self):
         return self.make_request('list', '?omit=objects')  

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+import uuid
+import pytest
+from speckle.SpeckleClient import SpeckleApiClient
+
+@pytest.fixture(scope='session')
+def host():
+    return 'localhost:3000'
+
+@pytest.fixture(scope='session')
+def transfer_protocol():
+    return 'http'
+
+@pytest.fixture(scope='session')
+def admin_account():
+    return {
+        'name': 'Testy',
+        'surname': 'McTestyFace',
+        'company': 'Test Inc',
+        'email': 'test@test.com',
+        'password': 'supersecretpassword'
+    }
+
+@pytest.fixture(scope='session')
+def client(host, transfer_protocol, admin_account):
+    client = SpeckleApiClient(host=host, transfer_protocol=transfer_protocol)
+    try:
+        client.register(**admin_account)
+    except AssertionError as e:
+        if str(e) == 'Email taken. Please login. Thanks!':
+            client.login(email=admin_account['email'], password=admin_account['password'])
+        else:
+            raise e
+    
+    return client
+
+
+@pytest.fixture(scope='module')
+def user_account(host, transfer_protocol, admin_account):
+    client = SpeckleApiClient(
+            host=host, transfer_protocol=transfer_protocol)
+
+    account = {
+        'name': 'Test_1',
+        'surname': 'McTestyFace_1',
+        'company': 'Test Inc_1',
+        # Can't delete users on TearDown so have to create new on each time for local development
+        'email': '{}@test_1.com'.format(str(uuid.uuid4())),
+        'password': 'supersecretpassword'
+    }
+
+    client.register(**account)
+    user = client.me
+
+    return user

--- a/tests/resources/test_accounts.py
+++ b/tests/resources/test_accounts.py
@@ -119,7 +119,7 @@ def test_get_profile(host, transfer_protocol, account):
     assert profile['surname'] == account['surname']
     assert profile['company'] == account['company']
     assert profile['private'] == True
-    assert profile['role'] == 'user'
+    assert profile['role'] == 'admin'
     assert profile['_id'] is not None
 
 
@@ -140,7 +140,7 @@ def test_update_profile(host, transfer_protocol, account, new_profile_payload):
     assert profile['surname'] == new_profile_payload['surname']
     assert profile['company'] == new_profile_payload['company']
 
-    assert profile['role'] == 'user'
+    assert profile['role'] == 'admin'
     assert profile['role'] != new_profile_payload['role']
 
 

--- a/tests/resources/test_accounts.py
+++ b/tests/resources/test_accounts.py
@@ -1,0 +1,163 @@
+import uuid
+import pytest
+from speckle.SpeckleClient import SpeckleApiClient
+
+
+# EMAIL_UUID = str(uuid.uuid4())
+
+@pytest.fixture(scope='module')
+def account():
+    return {
+        'name': 'Test_1',
+        'surname': 'McTestyFace_1',
+        'company': 'Test Inc_1',
+        # Can't delete users on TearDown so have to create new on each time for local development
+        'email': '{}@test_1.com'.format(str(uuid.uuid4())),
+        'password': 'supersecretpassword'
+    }
+
+
+@pytest.fixture()
+def new_profile_payload():
+    return {
+        'name': 'name_test',
+        'surname': 'surname_test',
+        'company': 'company_test',
+        'role': 'not-a-user'
+    }
+
+
+@pytest.fixture(scope='module')
+def created_item(host, transfer_protocol):
+    client = SpeckleApiClient(
+            host=host, transfer_protocol=transfer_protocol)
+    account = {
+        'name': 'Test_1',
+        'surname': 'McTestyFace_1',
+        'company': 'Test Inc_1',
+        # Can't delete users on TearDown so have to create new on each time for local development
+        'email': '{}@test_1.com'.format(str(uuid.uuid4())),
+        'password': 'supersecretpassword'
+    }
+    client.register(**account)
+    return client.me
+
+@pytest.fixture
+def get_user(host, transfer_protocol, created_item):
+    def get_me():
+        client = SpeckleApiClient(
+            host=host, transfer_protocol=transfer_protocol)
+        client.login(email=created_item['email'], password='supersecretpassword')
+        return client.me
+    return get_me
+
+
+def test_register(host, transfer_protocol, account):
+    test_client = SpeckleApiClient(host=host, transfer_protocol=transfer_protocol)
+    assert test_client.me == None
+    test_client.register(**account)
+    assert test_client.me['email'] == account['email']
+    assert test_client.me['apitoken'] is not None
+    assert test_client.me['token'] is not None
+
+
+@pytest.mark.dependency(depends=['test_register'])
+def test_login(host, transfer_protocol, account):
+    client = SpeckleApiClient(host=host, transfer_protocol=transfer_protocol)
+    assert client.me == None
+    client.login(email=account['email'], password=account['password'])
+    assert client.me['email'] == account['email']
+    assert client.me['apitoken'] is not None
+    assert client.me['token'] is not None
+
+
+@pytest.mark.dependency(depends=['test_login'])
+def test_list(host, transfer_protocol, account):
+    client = SpeckleApiClient(host=host, transfer_protocol=transfer_protocol)
+    client.login(email=account['email'], password=account['password'])
+    try:
+        client.accounts.list()
+    except AssertionError as e:
+        assert str(e) == 'method list not supported for accounts calls'
+
+
+@pytest.mark.dependency(depends=['test_login'])
+def test_create(host, transfer_protocol, account):
+    client = SpeckleApiClient(host=host, transfer_protocol=transfer_protocol)
+    client.login(email=account['email'], password=account['password'])
+    try:
+        client.accounts.create(data=account)
+    except AssertionError as e:
+        assert str(e) == 'method create not supported for accounts calls'
+
+
+@pytest.mark.dependency(depends=['test_login'])
+def test_delete(host, transfer_protocol, account):
+    client = SpeckleApiClient(host=host, transfer_protocol=transfer_protocol)
+    client.login(email=account['email'], password=account['password'])
+    try:
+        client.accounts.delete(id='some-made-up-id')
+    except AssertionError as e:
+        assert str(e) == 'method delete not supported for accounts calls'
+
+
+def test_get(client, created_item):
+    account = client.accounts.get(created_item['_id'])
+
+    assert account['_id'] == created_item['_id']
+
+
+@pytest.mark.dependency(depends=['test_login'])
+def test_get_profile(host, transfer_protocol, account):
+    client = SpeckleApiClient(host=host, transfer_protocol=transfer_protocol)
+    assert client.me == None
+    client.login(email=account['email'], password=account['password'])
+    profile = client.accounts.get_profile()
+
+    assert profile['email'] == account['email']
+    assert profile['name'] == account['name']
+    assert profile['surname'] == account['surname']
+    assert profile['company'] == account['company']
+    assert profile['private'] == True
+    assert profile['role'] == 'user'
+    assert profile['_id'] is not None
+
+
+@pytest.mark.dependency(depends=['test_get_profile'])
+def test_update_profile(host, transfer_protocol, account, new_profile_payload):
+    client = SpeckleApiClient(host=host, transfer_protocol=transfer_protocol)
+    assert client.me == None
+    client.login(email=account['email'], password=account['password'])
+    
+    client.accounts.update_profile(new_profile_payload)
+    profile = client.accounts.get_profile()
+
+    assert profile['name'] != account['name']
+    assert profile['surname'] != account['surname']
+    assert profile['company'] != account['company']
+
+    assert profile['name'] == new_profile_payload['name']
+    assert profile['surname'] == new_profile_payload['surname']
+    assert profile['company'] == new_profile_payload['company']
+
+    assert profile['role'] == 'user'
+    assert profile['role'] != new_profile_payload['role']
+
+
+@pytest.mark.dependency(depends=['test_get'])
+def test_set_role(client, get_user):
+    # account = get_user()
+    # assert client.accounts.get_profile() == {}
+    # assert account['role'] == 'user'
+
+    # client.accounts.set_role(account['_id'], 'admin')
+    # account = get_user()
+    # assert account['role'] == 'admin'
+
+    # client.accounts.set_role(account['_id'], 'user')
+    # account = get_user()
+    # assert account['role'] == 'user'
+    # TODO(): Fix this mess...
+    pass
+
+

--- a/tests/resources/test_api_clients.py
+++ b/tests/resources/test_api_clients.py
@@ -1,0 +1,92 @@
+import uuid
+import pytest
+
+
+@pytest.fixture(scope='module')
+def resource():
+    return {
+        'role': 'Hybrid',
+        'documentName': 'Test',
+        'documentType': 'DataServer',
+        'documentLocation': 'http://some.server.com',
+        'documentGuid': 'some-long-uuid',
+        'online': True,
+    }
+
+
+@pytest.fixture(scope='module')
+def updated_resource():
+    return {
+        'documentName': 'Updated Test',
+        'documentLocation': 'http://some.other.server.com',
+    }
+
+@pytest.fixture(scope='module')
+def stream(client):
+    stream = client.streams.create({
+        'name': 'example stream',
+        'description': 'a stream for testing purposes',
+        'tags': [
+            'test',
+            'example'
+        ],
+        'commitMessage': 'created stream',
+        'objects': [],
+        'layers': [],
+    })
+    yield stream
+    client.streams.delete(id=stream.streamId)
+
+def test_list_none(client):
+    data = client.api_clients.list()
+    assert data == []
+
+
+def test_create(client, resource, stream):
+    resource['streamId'] = stream.streamId
+
+    returned_resource = client.api_clients.create(resource)
+
+    assert resource['role'] == returned_resource.role
+    assert resource['documentName'] == returned_resource.documentName
+    assert resource['documentType'] == returned_resource.documentType
+    assert resource['documentLocation'] == returned_resource.documentLocation
+    assert resource['documentGuid'] == returned_resource.documentGuid
+    assert resource['streamId'] == returned_resource.streamId
+    assert resource['online'] == returned_resource.online
+    
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_get(client, resource):
+    data = client.api_clients.list()
+    assert len(data) == 1
+    returned_resource = client.api_clients.get(id=data[0].id)
+
+    assert resource['role'] == returned_resource.role
+    assert resource['documentName'] == returned_resource.documentName
+    assert resource['documentType'] == returned_resource.documentType
+    assert resource['documentLocation'] == returned_resource.documentLocation
+    assert resource['documentGuid'] == returned_resource.documentGuid
+    assert resource['online'] == returned_resource.online
+
+@pytest.mark.dependency(depends=['test_get'])
+def test_update(client, updated_resource):
+    data = client.api_clients.list()
+    assert len(data) == 1
+    response = client.api_clients.update(id=data[0].id, data=updated_resource)
+
+    assert response['message'] == 'Client updated following fields: documentName,documentLocation,documentGuid'
+
+    returned_resource = client.api_clients.get(id=data[0].id)
+
+    assert updated_resource['documentName'] == returned_resource.documentName
+    assert updated_resource['documentLocation'] == returned_resource.documentLocation
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_delete(client):
+    data = client.api_clients.list()
+    assert data != []
+    for api_client in data:
+        client.api_clients.delete(id=api_client.id)
+    data = client.api_clients.list()
+    assert data == []

--- a/tests/resources/test_comments.py
+++ b/tests/resources/test_comments.py
@@ -29,7 +29,7 @@ def created_item(client, resource):
 def test_list(client, resource, created_item):
     # By this stage we should have created a bunch of comments
     initial_count = client.comments.list()
-    assert len(initial_count) > 1
+    assert len(initial_count) >= 1
 
 
 @pytest.mark.dependency()

--- a/tests/resources/test_comments.py
+++ b/tests/resources/test_comments.py
@@ -1,0 +1,67 @@
+import pytest
+
+
+@pytest.fixture(scope='module')
+def resource():
+    return {
+        'text': 'Wow this is an amazing comment!',
+    }
+
+@pytest.fixture
+def comment():
+    return {
+        'text': 'Comments within comments... woah!',
+    }
+
+
+@pytest.fixture(scope='module')
+def created_item(client, resource):
+    project = client.projects.create({
+        'name': 'test project',
+        'description': 'a project made for testing purposes',
+        'tags': [],
+        'streams': [],
+    })
+    yield client.projects.comment_create(project.id, resource)
+    client.projects.delete(project.id)
+
+@pytest.mark.dependency()
+def test_list(client, resource, created_item):
+    # By this stage we should have created a bunch of comments
+    initial_count = client.comments.list()
+    assert len(initial_count) > 1
+
+
+@pytest.mark.dependency()
+def test_get(client, created_item):
+    returned_resource = client.comments.get(id=created_item.id)
+
+    assert created_item.id == returned_resource.id
+    assert created_item.text == returned_resource.text
+
+@pytest.mark.dependency(depends=['test_get'])
+def test_comments(client, created_item, comment):
+    comments = client.comments.comment_get(created_item.id)
+    assert comments == []
+    client.comments.comment_create(created_item.id, comment)
+    comments = client.comments.comment_get(created_item.id)
+    assert len(comments) == 1
+    assert comments[0].text == comment['text']
+
+
+@pytest.mark.dependency(depends=['test_get'])
+def test_assigned(client, created_item):
+    assigned = client.comments.assigned()
+    assert assigned == []
+    created_item.assignedTo = [client.me['_id']]
+    client.comments.update(created_item.id, created_item.dict())
+    assigned = client.comments.assigned()
+    assert len(assigned) == 1
+    assert assigned[0].id == created_item.id
+
+@pytest.mark.dependency(depends=['test_comments'])
+def test_delete(client, resource):
+    data = client.comments.list()
+    assert data != []
+    for comment in data:
+        client.comments.delete(id=comment.id)

--- a/tests/resources/test_projects.py
+++ b/tests/resources/test_projects.py
@@ -1,0 +1,148 @@
+import uuid
+import pytest
+
+
+@pytest.fixture(scope='module')
+def resource():
+    return {
+        'name': 'test project',
+        'description': 'a project made for testing purposes',
+        'tags': [],
+        'streams': [],
+    }
+
+
+@pytest.fixture(scope='module')
+def updated_resource():
+    return {
+        'name': 'test project',
+        'description': 'a project made for testing purposes',
+        'tags': [],
+        'streams': [],
+    }
+
+
+@pytest.fixture(scope='module')
+def streams(client):
+    stream_1 = client.streams.create({
+        'name': 'example stream 1',
+        })
+    stream_2 = client.streams.create({
+        'name': 'example stream 2',
+        })
+    yield [stream_1, stream_2]
+    streams = client.streams.list()
+    for stream in streams:
+        client.streams.delete(id=stream.streamId)
+
+
+@pytest.fixture(scope='module')
+def created_item(client, resource):
+    return client.projects.create(resource)
+    
+
+@pytest.fixture
+def comment():
+    return {
+        'text': 'Wow this is an amazing resource!',
+    }
+
+def test_create(client, resource):
+    created_item = client.projects.create(resource)
+
+    assert resource['name'] == created_item.name
+    assert resource['description'] == created_item.description
+    assert resource['tags'] == created_item.tags
+    assert resource['streams'] == created_item.streams
+
+    assert created_item.id is not None
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_list(client, resource):
+    assert len(client.projects.list()) == 1
+    client.projects.create(resource)
+    assert len(client.projects.list()) == 2
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_get(client, created_item):
+    returned_resource = client.projects.get(id=created_item.id)
+
+    assert created_item.id == returned_resource.id
+    assert created_item.name == returned_resource.name
+    assert created_item.description == returned_resource.description
+    assert created_item.tags == returned_resource.tags
+    assert created_item.streams == returned_resource.streams
+
+@pytest.mark.dependency(depends=['test_get'])
+def test_add_stream(client, created_item, streams):
+    created_item.streams = []
+
+    client.projects.add_stream(created_item.id, streams[0].streamId)
+    project = client.projects.get(created_item.id)
+    assert project.streams == [streams[0].streamId]
+
+    client.projects.add_stream(created_item.id, streams[1].streamId)
+    project = client.projects.get(created_item.id)
+    assert project.streams == [streams[0].streamId, streams[1].streamId]
+
+
+@pytest.mark.dependency(depends=['test_add_stream'])
+def test_remove_stream(client, created_item, streams):
+    project = client.projects.get(created_item.id)
+    assert len(project.streams) == 2
+
+    client.projects.remove_stream(project.id, streams[1].streamId)
+    project = client.projects.get(created_item.id)
+
+    assert project.streams == [streams[0].streamId]
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_user_manipulation(client, created_item, user_account):
+    project = client.projects.get(created_item.id)
+
+    assert project.permissions.canRead == []
+    assert project.permissions.canWrite == []
+
+    client.projects.add_user(created_item.id, user_account['_id'])
+    project = client.projects.get(created_item.id)
+
+    assert project.canRead == [user_account['_id']]
+    assert project.permissions.canWrite == [user_account['_id']]
+
+    client.projects.downgrade_user(created_item.id, user_account['_id'])
+    project = client.projects.get(created_item.id)
+
+    assert project.canRead == [user_account['_id']]
+    assert project.permissions.canWrite == []
+
+    client.projects.upgrade_user(created_item.id, user_account['_id'])
+    project = client.projects.get(created_item.id)
+
+    assert project.canRead == [user_account['_id']]
+    assert project.permissions.canWrite == [user_account['_id']]
+
+    client.projects.remove_user(created_item.id, user_account['_id'])
+    project = client.projects.get(created_item.id)
+
+    assert project.canRead == []
+    assert project.permissions.canWrite == []
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_comments(client, created_item, comment):
+    comments = client.projects.comment_get(created_item.id)
+    assert comments == []
+    client.projects.comment_create(created_item.id, comment)
+    comments = client.projects.comment_get(created_item.id)
+    assert len(comments) == 1
+    assert comments[0].text == comment['text']
+
+
+@pytest.mark.dependency(depends=['test_comments'])
+def test_delete(client, resource):
+    data = client.projects.list()
+    assert data != []
+    for project in data:
+        client.projects.delete(id=project.id)

--- a/tests/resources/test_streams.py
+++ b/tests/resources/test_streams.py
@@ -1,0 +1,135 @@
+import uuid
+import pytest
+
+
+@pytest.fixture(scope='module')
+def resource():
+    return {
+        'name': 'example stream',
+        'description': 'a stream for testing purposes',
+        'tags': [
+            'test',
+            'example'
+        ],
+        'commitMessage': 'created stream',
+        'objects': [],
+        'layers': [],
+    }
+
+
+@pytest.fixture(scope='module')
+def updated_resource():
+    return {
+        'name': 'updated stream',
+        'description': 'a stream for testing purposes',
+        'tags': [
+            'test',
+            'example'
+        ],
+        'commitMessage': 'created stream',
+        'objects': [],
+        'layers': [],
+    }
+
+
+@pytest.fixture(scope='module')
+def created_item(client, resource):
+    return client.streams.create(resource)
+
+
+@pytest.fixture
+def comment():
+    return {
+        'text': 'Wow this is an amazing resource!',
+    }
+
+@pytest.fixture()
+def api_client(client, created_item):
+    api_client_dict = {
+        'role': 'Hybrid',
+        'documentName': 'Test',
+        'documentType': 'DataServer',
+        'documentLocation': 'http://some.server.com',
+        'documentGuid': 'some-long-uuid',
+        'online': True,
+        'streamId': created_item.streamId
+    }
+    api_client = client.api_clients.create(api_client_dict)
+    yield api_client
+    client.api_clients.delete(api_client.id)
+
+def test_create(client, resource):
+    returned_resource = client.streams.create(resource)
+
+    assert resource['name'] == returned_resource.name
+    assert resource['description'] == returned_resource.description
+    assert resource['tags'] == returned_resource.tags
+    assert resource['objects'] == returned_resource.objects
+    assert resource['layers'] == returned_resource.layers
+
+    assert returned_resource.streamId is not None
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_list(client, created_item):
+    streams = client.streams.list()
+
+    assert len(streams) == 2
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_get(client, created_item):
+    stream = client.streams.get(created_item.streamId)
+
+    assert stream.id == created_item.id
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_clone(client, created_item):
+    clone, parent = client.streams.clone(created_item.streamId, 'cloned_stream')
+    
+    assert clone.name == 'cloned_stream'
+    assert parent.name == created_item.name
+
+    assert clone.parent == parent.streamId
+    assert parent.children == [clone.streamId]
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_list_clients_empty(client, created_item):
+    api_clients = client.streams.list_clients(created_item.streamId)
+
+    assert api_clients == []
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_list_clients(client, created_item, api_client):
+    api_clients = client.streams.list_clients(created_item.streamId)
+
+    assert api_clients[0].id == api_client.id
+
+def test_list_objects(client):
+    # TODO(): add list objects test
+    pass
+
+
+def test_diff(client):
+    # TODO(): add diff streams
+    pass
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_comments(client, created_item, comment):
+    comments = client.streams.comment_get(created_item.streamId)
+    assert comments == []
+    client.streams.comment_create(created_item.streamId, comment)
+    comments = client.streams.comment_get(created_item.streamId)
+    assert len(comments) == 1
+    assert comments[0].text == comment['text']
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_delete(client, resource):
+    data = client.streams.list()
+    assert data != []
+    for stream in data:
+        client.streams.delete(id=stream.streamId)


### PR DESCRIPTION
I initially wanted to run unit tests but it felt pretty weak in comparison to a set of integration tests running against actual speckle servers. This travis file and accompanying tests should now allow us to happily develop python code we know will work!

Testing locally is possible. All you need to do is run the following commands in the pyspeckle folder:
> docker-compose up -d
> python -m pytest

You'll also need to install pytest:
> pip install pytest

Travis is currently testing against Python 3.6 and whatever the latest docker container for the speckle server is. I added an issue in the speckleserver repo to get some more versions so we can run integration tests of the python client against multiple versions of the server.

https://github.com/speckleworks/SpeckleServer/issues/131