### PR TITLE
ci(semantic release): setup semantic release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,10 @@
+{
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/github",
+        ["@semantic-release/exec", {
+            "publishCmd": "bash deploy.sh"
+        }]
+    ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,35 @@
 language: python
-
 python:
-  - '3.6'
-
+- '3.6'
 services:
-  - docker
-
-env: 
+- docker
+env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.24.0
-
+  - DOCKER_COMPOSE_VERSION=1.24.0
+  - PYPI_USERNAME=botsalot
+  - secure: fuF5Rvlcp4LbGK3POvDNNW4FSTnY+maMth4EkZDZDlrECYBkcCayViwsmUESwWJuyBA6Dizu7SLKCROyG7wzqmowIZKG+rNbK3dRggO9r7Rn3dCY1rB1rNRMMwaoDDhz/FFXTHBSUpHDD9Zq5+1AtlM2mb0pPYf+KKvVUb0bn4kqdkZrRfaFBAtRwiOZ3Ws7ySgf6dHsXfMvBGIwA63YIDa6xsJmu04EACRS9rHMELf8BG0PsEi54KrhWZF2+QhDY0uAfdcF11CgD6aGm/n1OohsqDNbn2aCT2DFaHi954eypmyWiSvda3BVBTlW8OL5kwQZxVvOCwD/h/BKkHVtNMhLLsvdTm9lec3D8+LYCvpzGfBAgFvH6F9txSmA6nt5/4TVh0YlB+NKaSPwWNJ6RomvZQ2rI6U1DrhsT9ZDhd2qxOlGRDI6NsjW9f/4AGy38J3cDAs4DRgSOypONpNvWG8OIHIYASWodcwbcESPncouEo5amGoqIa3x+irYUj3HjpdpmGQJI+bW1vMuh2/zUIJkVjY7ANnTAyWmmohCgv8KpYwJotsFZmoZPtkvLTXlaEa0t4FOMmWzzv99o7dNKSjrDSqQFYtlIyBtiYxgghRPiOH4WwuBNkcTTOB21I+L8pTG16ys1/DUIauaYuuRsmHngpIXyXlU7B4d7b1I7KA=
 install:
-  - pip install -r requirements.txt
-  - pip install -r dev-requirements.txt
-
+- pip install -r requirements.txt
+- pip install -r dev-requirements.txt
 jobs:
   include:
   - stage: test
     before_install:
-      - sudo rm /usr/local/bin/docker-compose
-      - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-      - chmod +x docker-compose
-      - sudo mv docker-compose /usr/local/bin
+    - sudo rm /usr/local/bin/docker-compose
+    - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname
+      -s`-`uname -m` > docker-compose
+    - chmod +x docker-compose
+    - sudo mv docker-compose /usr/local/bin
     script:
-      - docker-compose up -d
-      # Wait 10s to make sure docker-compose has properly spun up speckle server
-      - sleep 10s
-      - python -m pytest --cov=speckle tests/ 
+    - docker-compose up -d
+    - sleep 10s
+    - python -m pytest --cov=speckle tests/
   - stage: deploy
     if: branch = master AND (NOT type IN (pull_request))
     before_install:
-      - npm i -g npm@6.6.0
-      - npm install @semantic-release/exec
+    - npm i -g npm@6.6.0
+    - npm install @semantic-release/exec
     script:
-      - git config --global user.email "releases@speckleworks.com"
-      - git config --global user.name "specklebot"
-      - npx semantic-release
+    - git config --global user.email "devops@speckle.works"
+    - git config --global user.name "botsalot"
+    - npx semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,29 @@ env:
   global:
     - DOCKER_COMPOSE_VERSION=1.24.0
 
-before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-
 install:
   - pip install -r requirements.txt
-  - pip install pytest pytest-cov
+  - pip install -r dev-requirements.txt
 
-script:
-  - docker-compose up -d
-  # Wait 10s to make sure docker-compose has properly spun up speckle server
-  - sleep 10s
-  - python -m pytest --cov=speckle tests/ 
+jobs:
+  include:
+  - stage: test
+    before_install:
+      - sudo rm /usr/local/bin/docker-compose
+      - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+      - chmod +x docker-compose
+      - sudo mv docker-compose /usr/local/bin
+    script:
+      - docker-compose up -d
+      # Wait 10s to make sure docker-compose has properly spun up speckle server
+      - sleep 10s
+      - python -m pytest --cov=speckle tests/ 
+  - stage: deploy
+    if: branch = master AND (NOT type IN (pull_request))
+    before_install:
+      - npm i -g npm@6.6.0
+      - npm install @semantic-release/exec
+    script:
+      - git config --global user.email "releases@speckleworks.com"
+      - git config --global user.name "specklebot"
+      - npx semantic-release

--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ A Python Speckle Client
 > Speckle: open digital infrastructure for designing, making and operating the built environment.
 > We reimagine the design process from the Internet up: Speckle is an open source (MIT) initiative for developing an extensible Design & AEC data communication and collaboration platform.
 
-## Updates
-
-### January 15, 2019
-
-Pip distribution updated to version 0.2.5. Remember to `pip install speckle --upgrade` to stay up-to-date.
 
 ## Installation
 PySpeckle can be installed through `pip`:
@@ -27,5 +22,35 @@ PySpeckle is a light Python wrapper / interface for the Speckle framework. It ca
 
 At the moment, it copies the same method names from the .NET `SpeckleApiClient`, for consistency's sake. Although the functions are mostly labelled 'Async', they are not yet. This could eventually be implemented with `requests_futures` or `grequests` or similar.
 
-## Notes
-SpeckleBlender is written and maintained by [Tom Svilans](http://tomsvilans.com) ([Github](https://github.com/tsvilans)).
+## Quick Start
+Here is how you initialise a client, authenticate and start speckling:
+```python
+from speckle import SpeckleApiClient
+
+client = SpeckleApiClient('hestia.speckle.works')
+
+client.login(
+    email='test@test.com',
+    password='Speckle<3Python'
+)
+
+stream_id = 'HjenwS2s'
+
+objects = client.streams.list_objects(stream_id)
+
+for object in objects:
+  print(object.dict())
+```
+
+Usage documentation can be found [here](https://pyspeckle.readthedocs.io/en/latest/).
+
+
+
+## Maintainers
+SpeckleBlender is written and maintained by [Tom Svilans](http://tomsvilans.com) ([Github](https://github.com/tsvilans)), [Izzy Lyseggen](https://github.com/izzylys) and [Antoine Dao](https://github.com/antoinedao).
+
+## Updates
+
+### January 15, 2019
+
+Pip distribution updated to version 0.2.5. Remember to `pip install speckle --upgrade` to stay up-to-date.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+deploy_to_pypi() {
+  echo "Building distribution"
+  python setup.py sdist bdist_wheel
+  echo "Pushing new version to PyPi"
+  twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 
+}
+
+deploy_to_pypi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+twine==1.13.0
+pylint==2.3.1
+pytest==4.5.0
+pytest-cov==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,6 @@ more-itertools==7.0.0
 pluggy==0.11.0
 py==1.8.0
 pydantic==0.26
-pylint==2.3.1
-pytest==4.5.0
 requests==2.22.0
 six==1.12.0
 typed-ast==1.3.5

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+import re
+import setuptools
+import sys
+
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="speckle",
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
+    author="Speckle Works",
+    description="A Python client for Speckle servers.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/specklworks.pyspeckle",
+    packages=setuptools.find_packages(exclude=["tests"]),
+    install_requires=required,
+    classifiers=[
+        "Programming Language :: Python :: 3.6",
+        "Operating System :: OS Independent"
+    ],
+)


### PR DESCRIPTION
This will trigger build and deployments to PyPi based on commit messages. For more information
checkout this: https://blog.greenkeeper.io/introduction-to-semantic-release-33f73b117c8. I also
recommend installing commitizen: https://github.com/commitizen/cz-cli.

For this change to work the following must be done:
* Now: Tag the commit the latest version was deployed from so semantic-release can appropriately bump up the version
* Now: @tsvilans needs to dump the username and password for the PyPi account he deployed to originally [here](https://travis-ci.com/speckleworks/PySpeckle/settings). Or alternatively you can add someone else (the soon to be `speckle bot` account for example as an admin which can then dump their own access keys in Travis (encrypted of course)

* Future Commits: Semantic-release makes deployment of new code to PyPi and version management trivial but it comes at the cost of applying a rather strict commit style. This effort can be removed by using [commitizen](https://github.com/commitizen/cz-cli) which can be installed really easily on most computers like so:
> npm install -g commitizen cz-conventional-changelog && echo '{ "path": "cz-conventional-changelog" }' > ~/.czrc

Note: you need to have NodeJS installed on your machine first.