### PR TITLE
Dynamic schemas

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,27 +11,36 @@ services:
       - mongo
     environment:
       - SERVER_NAME=Docker Speckle Server
+      - CANONICAL_URL=http://localhost:3000
       - SESSION_SECRET=helloworld
-      - REQ_SIZE=16mb
-      - INDENT_RESPONSES=false
-      - MONGODB_URI=mongodb://mongo:27017/speckle_docker
-      - REDIS_URL=redis://redis:6379
-      - EXPOSE_EMAILS=false
+      # optional
+      - MAX_PROC=1
       - PUBLIC_STREAMS=true
-      - PLUGIN_DIRS="./node_modules/@speckle,./plugins"
+      - PLUGIN_DIRS=./node_modules/@speckle,./plugins
+      - PORT=3000
+      - IP=0.0.0.0
+      - REQ_SIZE=10mb
+      - MONGODB_URI=mongodb://mongo:27017/speckle_v3
+      - REDIS_URL=redis://redis:6379
+      - INDENT_RESPONSES=false
+      - EXPOSE_EMAILS=true
+      - FIRST_USER_ADMIN=true
+      - PUBLIC_REGISTRATION=true
+      - USE_LOCAL=true
+      - REDIRECT_URLS=https://app.speckle.systems
     links:
       - redis
       - mongo
   mongo:
     image: mongo:latest
-    ports:
-      - '27017:27017'
+    # ports:
+    #   - '27017:27017'
     networks:
       - webnet
   redis:
     image: redis:alpine
-    ports:
-      - '6379:6379'
+    # ports:
+    #   - '6379:6379'
     networks:
       - webnet
 networks:

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -1,6 +1,7 @@
 import json
 from requests import Request
 from pydantic import BaseModel
+from pydoc import locate
 from typing import List, Optional
 import dataclasses
 from dataclasses import dataclass
@@ -113,6 +114,8 @@ class ResourceBase(object):
             return schema.parse_obj(response)
         elif comment:
             return self.comment_schema.parse_obj(response)
+        elif 'type' in response and hasattr(locate("speckle.schemas"), response['type']):
+            return locate("speckle.schemas.{}".format(response['type'])).parse_obj(response)   
         elif self.schema:
             return self.schema.parse_obj(response)
         else:

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -23,7 +23,7 @@ class SpeckleObject(ResourceBaseSchema):
     children: Optional[List[str]]
     ancestors: Optional[List[str]]
 
-
+    '''
     def dict(self):
         json_string = json.dumps(super(SpeckleObject, self).dict()['properties'])
 
@@ -33,6 +33,7 @@ class SpeckleObject(ResourceBaseSchema):
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(SpeckleObject, self).dict()
+    '''
 
 
 class Resource(ResourceBase):

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -23,8 +23,8 @@ class SpeckleObject(ResourceBaseSchema):
     children: Optional[List[str]]
     ancestors: Optional[List[str]]
 
-    '''
-    def dict(self):
+    
+    def dict(self, include=None, exclude=None, by_alias=False, exclude_unset=False, exclude_defaults=False, exclude_none=False):
         json_string = json.dumps(super(SpeckleObject, self).dict()['properties'])
 
         self.geometryHash = hashlib.md5(
@@ -32,8 +32,8 @@ class SpeckleObject(ResourceBaseSchema):
 
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
-        return super(SpeckleObject, self).dict()
-    '''
+        return super(SpeckleObject, self).dict(include=include, exclude=exclude)
+    
 
 
 class Resource(ResourceBase):

--- a/speckle/schemas/Arc.py
+++ b/speckle/schemas/Arc.py
@@ -3,21 +3,14 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
 from speckle.schemas import Plane, Interval
 
 NAME = 'arc'
 
-class Schema(ResourceBaseSchema):
+class Schema(SpeckleObject):
     type: Optional[str] = "Arc"
     name: Optional[str] = "SpeckleArc"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
     Radius: float = 0.0
     StartAngle: float = 0.0
     EndAngle: float = 0.0
@@ -25,6 +18,7 @@ class Schema(ResourceBaseSchema):
     Domain: Interval.Schema = Interval.Schema()
     Plane: Plane = Plane.Schema()
 
+    '''
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])
 
@@ -34,3 +28,4 @@ class Schema(ResourceBaseSchema):
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(Schema, self).dict()
+    '''

--- a/speckle/schemas/Arc.py
+++ b/speckle/schemas/Arc.py
@@ -3,12 +3,13 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.schemas import Plane, Interval
 
-NAME = 'null'
+NAME = 'arc'
 
 class Schema(ResourceBaseSchema):
-    type: Optional[str] = "Null"
-    name: Optional[str] = "SpeckleNull"
+    type: Optional[str] = "Arc"
+    name: Optional[str] = "SpeckleArc"
     geometryHash: Optional[str]  # Is immediately replaced anyways
     hash: Optional[str]  # Is immediately replaced anyways
     applicationId: Optional[str]
@@ -17,6 +18,12 @@ class Schema(ResourceBaseSchema):
     parent: Optional[List[str]]
     children: Optional[List[str]]
     ancestors: Optional[List[str]]
+    Radius: float = 0.0
+    StartAngle: float = 0.0
+    EndAngle: float = 0.0
+    AngleRadians: float = 0.0
+    Domain: Interval.Schema = Interval.Schema()
+    Plane: Plane = Plane.Schema()
 
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])

--- a/speckle/schemas/Arc.py
+++ b/speckle/schemas/Arc.py
@@ -17,15 +17,3 @@ class Schema(SpeckleObject):
     AngleRadians: float = 0.0
     Domain: Interval.Schema = Interval.Schema()
     Plane: Plane = Plane.Schema()
-
-    '''
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()
-    '''

--- a/speckle/schemas/Brep.py
+++ b/speckle/schemas/Brep.py
@@ -13,13 +13,3 @@ class Schema(SpeckleObject):
     name: Optional[str] = "SpeckleBrep"
     displayValue: Optional[Mesh.Schema]
     rawData: str = ""
-
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()

--- a/speckle/schemas/Brep.py
+++ b/speckle/schemas/Brep.py
@@ -4,20 +4,13 @@ from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
 from speckle.schemas import Mesh
+from speckle.resources.objects import SpeckleObject
 
 NAME = 'brep'
 
-class Schema(ResourceBaseSchema):
+class Schema(SpeckleObject):
     type: Optional[str] = "Brep"
     name: Optional[str] = "SpeckleBrep"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
     displayValue: Optional[Mesh.Schema]
     rawData: str = ""
 

--- a/speckle/schemas/Brep.py
+++ b/speckle/schemas/Brep.py
@@ -3,6 +3,7 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.schemas import Mesh
 
 NAME = 'brep'
 
@@ -17,7 +18,8 @@ class Schema(ResourceBaseSchema):
     parent: Optional[List[str]]
     children: Optional[List[str]]
     ancestors: Optional[List[str]]
-    displayValue: dict = {}
+    displayValue: Optional[Mesh.Schema]
+    rawData: str = ""
 
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])

--- a/speckle/schemas/Brep.py
+++ b/speckle/schemas/Brep.py
@@ -1,0 +1,30 @@
+import json
+import hashlib
+from pydantic import BaseModel, validator
+from typing import List, Optional
+from speckle.base.resource import ResourceBaseSchema
+
+NAME = 'brep'
+
+class Schema(ResourceBaseSchema):
+    type: Optional[str] = "Brep"
+    name: Optional[str] = "SpeckleBrep"
+    geometryHash: Optional[str]  # Is immediately replaced anyways
+    hash: Optional[str]  # Is immediately replaced anyways
+    applicationId: Optional[str]
+    properties: Optional[dict]
+    partOf: Optional[List[str]]
+    parent: Optional[List[str]]
+    children: Optional[List[str]]
+    ancestors: Optional[List[str]]
+    displayValue: dict = {}
+
+    def dict(self):
+        json_string = json.dumps(super(Schema, self).dict()['properties'])
+
+        self.geometryHash = hashlib.md5(
+            json_string.encode('utf-8')).hexdigest()
+
+        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
+
+        return super(Schema, self).dict()

--- a/speckle/schemas/Interval.py
+++ b/speckle/schemas/Interval.py
@@ -4,10 +4,12 @@ from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
 
+
 NAME = 'interval'
 
 class Schema(ResourceBaseSchema):
     type: str = "Interval"
+    name: Optional[str] = "SpeckleInterval"
     Start: float = 0.0
     End: float = 0.0
     '''

--- a/speckle/schemas/Interval.py
+++ b/speckle/schemas/Interval.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
 
-
 NAME = 'interval'
 
 class Schema(ResourceBaseSchema):
@@ -12,16 +11,3 @@ class Schema(ResourceBaseSchema):
     name: Optional[str] = "SpeckleInterval"
     Start: float = 0.0
     End: float = 0.0
-    '''
-
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()
-
-    '''

--- a/speckle/schemas/Interval.py
+++ b/speckle/schemas/Interval.py
@@ -4,19 +4,13 @@ from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
 
-NAME = 'null'
+NAME = 'interval'
 
 class Schema(ResourceBaseSchema):
-    type: Optional[str] = "Null"
-    name: Optional[str] = "SpeckleNull"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
+    type: str = "Interval"
+    Start: float = 0.0
+    End: float = 0.0
+    '''
 
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])
@@ -27,3 +21,5 @@ class Schema(ResourceBaseSchema):
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(Schema, self).dict()
+
+    '''

--- a/speckle/schemas/Line.py
+++ b/speckle/schemas/Line.py
@@ -3,12 +3,13 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.schemas import Interval
 
-NAME = 'null'
+NAME = 'line'
 
 class Schema(ResourceBaseSchema):
-    type: Optional[str] = "Null"
-    name: Optional[str] = "SpeckleNull"
+    type: Optional[str] = "Line"
+    name: Optional[str] = "SpeckleLine"
     geometryHash: Optional[str]  # Is immediately replaced anyways
     hash: Optional[str]  # Is immediately replaced anyways
     applicationId: Optional[str]
@@ -17,6 +18,8 @@ class Schema(ResourceBaseSchema):
     parent: Optional[List[str]]
     children: Optional[List[str]]
     ancestors: Optional[List[str]]
+    Value: List[float] = []
+    Domain: 'Interval' = Interval()
 
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])

--- a/speckle/schemas/Line.py
+++ b/speckle/schemas/Line.py
@@ -14,13 +14,3 @@ class Schema(SpeckleObject):
     name: Optional[str] = "SpeckleLine"
     Value: List[float] = []
     Domain: 'Interval' = Interval()
-
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()

--- a/speckle/schemas/Line.py
+++ b/speckle/schemas/Line.py
@@ -1,23 +1,17 @@
 import json
+import json
 import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
 from speckle.schemas import Interval
 
 NAME = 'line'
 
-class Schema(ResourceBaseSchema):
+class Schema(SpeckleObject):
     type: Optional[str] = "Line"
     name: Optional[str] = "SpeckleLine"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
     Value: List[float] = []
     Domain: 'Interval' = Interval()
 

--- a/speckle/schemas/Mesh.py
+++ b/speckle/schemas/Mesh.py
@@ -7,7 +7,7 @@ from speckle.base.resource import ResourceBaseSchema
 NAME = 'mesh'
 
 class Schema(ResourceBaseSchema):
-    type: Optional[str] = "Mesh"
+    type: str = "Mesh"
     name: Optional[str] = "SpeckleMesh"
     geometryHash: Optional[str]  # Is immediately replaced anyways
     hash: Optional[str]  # Is immediately replaced anyways

--- a/speckle/schemas/Mesh.py
+++ b/speckle/schemas/Mesh.py
@@ -14,14 +14,3 @@ class Schema(SpeckleObject):
     faces: List[int] = []
     texture_coordinates: Optional[List[float]]
     colors: Optional[List[int]]
-
-
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()

--- a/speckle/schemas/Mesh.py
+++ b/speckle/schemas/Mesh.py
@@ -1,0 +1,34 @@
+import json
+import hashlib
+from pydantic import BaseModel, validator
+from typing import List, Optional
+from speckle.base.resource import ResourceBaseSchema
+
+NAME = 'mesh'
+
+class Schema(ResourceBaseSchema):
+    type: Optional[str] = "Mesh"
+    name: Optional[str] = "SpeckleMesh"
+    geometryHash: Optional[str]  # Is immediately replaced anyways
+    hash: Optional[str]  # Is immediately replaced anyways
+    applicationId: Optional[str]
+    properties: Optional[dict]
+    partOf: Optional[List[str]]
+    parent: Optional[List[str]]
+    children: Optional[List[str]]
+    ancestors: Optional[List[str]]
+    vertices: List[float] = []
+    faces: List[int] = []
+    texture_coordinates: Optional[List[float]]
+    colors: Optional[List[int]]
+
+
+    def dict(self):
+        json_string = json.dumps(super(Schema, self).dict()['properties'])
+
+        self.geometryHash = hashlib.md5(
+            json_string.encode('utf-8')).hexdigest()
+
+        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
+
+        return super(Schema, self).dict()

--- a/speckle/schemas/Mesh.py
+++ b/speckle/schemas/Mesh.py
@@ -3,20 +3,13 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
 
 NAME = 'mesh'
 
-class Schema(ResourceBaseSchema):
+class Schema(SpeckleObject):
     type: str = "Mesh"
     name: Optional[str] = "SpeckleMesh"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
     vertices: List[float] = []
     faces: List[int] = []
     texture_coordinates: Optional[List[float]]

--- a/speckle/schemas/Null.py
+++ b/speckle/schemas/Null.py
@@ -1,0 +1,29 @@
+import json
+import hashlib
+from pydantic import BaseModel, validator
+from typing import List, Optional
+from speckle.base.resource import ResourceBaseSchema
+
+NAME = 'null'
+
+class Schema(ResourceBaseSchema):
+    type: Optional[str]
+    name: Optional[str]
+    geometryHash: Optional[str]  # Is immediately replaced anyways
+    hash: Optional[str]  # Is immediately replaced anyways
+    applicationId: Optional[str]
+    properties: Optional[dict]
+    partOf: Optional[List[str]]
+    parent: Optional[List[str]]
+    children: Optional[List[str]]
+    ancestors: Optional[List[str]]
+
+    def dict(self):
+        json_string = json.dumps(super(Schema, self).dict()['properties'])
+
+        self.geometryHash = hashlib.md5(
+            json_string.encode('utf-8')).hexdigest()
+
+        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
+
+        return super(Schema, self).dict()

--- a/speckle/schemas/Null.py
+++ b/speckle/schemas/Null.py
@@ -3,21 +3,16 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
+
 
 NAME = 'null'
 
-class Schema(ResourceBaseSchema):
+class Schema(SpeckleObject):
     type: Optional[str] = "Null"
     name: Optional[str] = "SpeckleNull"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
 
+    '''
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])
 
@@ -27,3 +22,4 @@ class Schema(ResourceBaseSchema):
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(Schema, self).dict()
+    '''

--- a/speckle/schemas/Null.py
+++ b/speckle/schemas/Null.py
@@ -11,15 +11,3 @@ NAME = 'null'
 class Schema(SpeckleObject):
     type: Optional[str] = "Null"
     name: Optional[str] = "SpeckleNull"
-
-    '''
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()
-    '''

--- a/speckle/schemas/Plane.py
+++ b/speckle/schemas/Plane.py
@@ -15,15 +15,3 @@ class Schema(SpeckleObject):
     Normal: Vector.Schema = Vector.Schema(Value=[0,0,1])
     Xdir: Vector.Schema = Vector.Schema(Value=[1,0,0])
     Ydir: Vector.Schema = Vector.Schema(Value=[0,1,0])
-
-    '''
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()
-    '''

--- a/speckle/schemas/Plane.py
+++ b/speckle/schemas/Plane.py
@@ -3,21 +3,18 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.schemas import Point, Vector
 
-NAME = 'null'
+NAME = 'plane'
 
 class Schema(ResourceBaseSchema):
-    type: Optional[str] = "Null"
-    name: Optional[str] = "SpeckleNull"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
+    type: Optional[str] = "Plane"
+    Origin: Point.Schema = Point.Schema(Value=[0,0,0])
+    Normal: Vector.Schema = Vector.Schema(Value=[0,0,1])
+    Xdir: Vector.Schema = Vector.Schema(Value=[1,0,0])
+    Ydir: Vector.Schema = Vector.Schema(Value=[0,1,0])
 
+    '''
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])
 
@@ -27,3 +24,4 @@ class Schema(ResourceBaseSchema):
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(Schema, self).dict()
+    '''

--- a/speckle/schemas/Plane.py
+++ b/speckle/schemas/Plane.py
@@ -3,12 +3,14 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
 from speckle.schemas import Point, Vector
 
 NAME = 'plane'
 
-class Schema(ResourceBaseSchema):
+class Schema(SpeckleObject):
     type: Optional[str] = "Plane"
+    name: Optional[str] = "SpecklePlane"
     Origin: Point.Schema = Point.Schema(Value=[0,0,0])
     Normal: Vector.Schema = Vector.Schema(Value=[0,0,1])
     Xdir: Vector.Schema = Vector.Schema(Value=[1,0,0])

--- a/speckle/schemas/Point.py
+++ b/speckle/schemas/Point.py
@@ -12,15 +12,3 @@ class Schema(SpeckleObject):
     type: str = "Point"
     name: Optional[str] = "SpecklePoint"
     Value: List[float] = [0,0,0]
-
-    '''
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()
-    '''

--- a/speckle/schemas/Point.py
+++ b/speckle/schemas/Point.py
@@ -3,11 +3,14 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
+
 
 NAME = 'point'
 
-class Schema(ResourceBaseSchema):
+class Schema(SpeckleObject):
     type: str = "Point"
+    name: Optional[str] = "SpecklePoint"
     Value: List[float] = [0,0,0]
 
     '''

--- a/speckle/schemas/Point.py
+++ b/speckle/schemas/Point.py
@@ -4,20 +4,13 @@ from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
 
-NAME = 'null'
+NAME = 'point'
 
 class Schema(ResourceBaseSchema):
-    type: Optional[str] = "Null"
-    name: Optional[str] = "SpeckleNull"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
+    type: str = "Point"
+    Value: List[float] = [0,0,0]
 
+    '''
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])
 
@@ -27,3 +20,4 @@ class Schema(ResourceBaseSchema):
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(Schema, self).dict()
+    '''

--- a/speckle/schemas/Polycurve.py
+++ b/speckle/schemas/Polycurve.py
@@ -3,24 +3,17 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
 from speckle.schemas import Interval
 
 NAME = 'polycurve'
 
-class Schema(ResourceBaseSchema):
+class Schema(SpeckleObject):
     type: Optional[str] = "Polycurve"
     name: Optional[str] = "SpecklePolycurve"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
     Segments: List[dict] = []
-    Closed: bool = False
     Domain: 'Interval' = Interval()
+    Closed: bool = False
 
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])

--- a/speckle/schemas/Polycurve.py
+++ b/speckle/schemas/Polycurve.py
@@ -14,13 +14,3 @@ class Schema(SpeckleObject):
     Segments: List[dict] = []
     Domain: 'Interval' = Interval()
     Closed: bool = False
-
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()

--- a/speckle/schemas/Polycurve.py
+++ b/speckle/schemas/Polycurve.py
@@ -3,12 +3,13 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.schemas import Interval
 
-NAME = 'null'
+NAME = 'polycurve'
 
 class Schema(ResourceBaseSchema):
-    type: Optional[str] = "Null"
-    name: Optional[str] = "SpeckleNull"
+    type: Optional[str] = "Polycurve"
+    name: Optional[str] = "SpecklePolycurve"
     geometryHash: Optional[str]  # Is immediately replaced anyways
     hash: Optional[str]  # Is immediately replaced anyways
     applicationId: Optional[str]
@@ -17,6 +18,9 @@ class Schema(ResourceBaseSchema):
     parent: Optional[List[str]]
     children: Optional[List[str]]
     ancestors: Optional[List[str]]
+    Segments: List[dict] = []
+    Closed: bool = False
+    Domain: 'Interval' = Interval()
 
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])

--- a/speckle/schemas/Vector.py
+++ b/speckle/schemas/Vector.py
@@ -4,20 +4,13 @@ from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
 
-NAME = 'null'
+NAME = 'vector'
 
 class Schema(ResourceBaseSchema):
-    type: Optional[str] = "Null"
-    name: Optional[str] = "SpeckleNull"
-    geometryHash: Optional[str]  # Is immediately replaced anyways
-    hash: Optional[str]  # Is immediately replaced anyways
-    applicationId: Optional[str]
-    properties: Optional[dict]
-    partOf: Optional[List[str]]
-    parent: Optional[List[str]]
-    children: Optional[List[str]]
-    ancestors: Optional[List[str]]
+    type: str = "Vector"
+    Value: List[float] = [0,0,1]
 
+    '''
     def dict(self):
         json_string = json.dumps(super(Schema, self).dict()['properties'])
 
@@ -27,3 +20,4 @@ class Schema(ResourceBaseSchema):
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(Schema, self).dict()
+    '''

--- a/speckle/schemas/Vector.py
+++ b/speckle/schemas/Vector.py
@@ -3,11 +3,14 @@ import hashlib
 from pydantic import BaseModel, validator
 from typing import List, Optional
 from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
+
 
 NAME = 'vector'
 
-class Schema(ResourceBaseSchema):
+class Schema(SpeckleObject):
     type: str = "Vector"
+    name: Optional[str] = "SpeckleVector"
     Value: List[float] = [0,0,1]
 
     '''

--- a/speckle/schemas/Vector.py
+++ b/speckle/schemas/Vector.py
@@ -12,15 +12,3 @@ class Schema(SpeckleObject):
     type: str = "Vector"
     name: Optional[str] = "SpeckleVector"
     Value: List[float] = [0,0,1]
-
-    '''
-    def dict(self):
-        json_string = json.dumps(super(Schema, self).dict()['properties'])
-
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
-
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
-
-        return super(Schema, self).dict()
-    '''

--- a/speckle/schemas/__init__.py
+++ b/speckle/schemas/__init__.py
@@ -1,0 +1,14 @@
+from speckle.base.resource import ResourceBaseSchema
+from pathlib import Path
+import sys
+import inspect
+import pkgutil
+from importlib import import_module
+
+
+for (_, name, _) in pkgutil.iter_modules([Path(__file__).parent]):
+
+    imported_module = import_module('.' + name, package=__name__)
+    
+    if hasattr(imported_module, 'Schema'):
+        setattr(sys.modules[__name__], name, imported_module.Schema)

--- a/tests/resources/test_streams.py
+++ b/tests/resources/test_streams.py
@@ -127,9 +127,9 @@ def test_comments(client, created_item, comment):
     assert len(comments) == 1
     assert comments[0].text == comment['text']
 
-@pytest.mark.dependency(depends=['test_create'])
-def test_delete(client, resource):
-    data = client.streams.list()
-    assert data != []
-    for stream in data:
-        client.streams.delete(id=stream.streamId)
+# @pytest.mark.dependency(depends=['test_create'])
+# def test_delete(client, resource):
+#     data = client.streams.list()
+#     assert data != []
+#     for stream in data:
+#         client.streams.delete(id=stream.streamId)


### PR DESCRIPTION
This is a pretty important one, but needs discussing.

So far, program clients such as `SpeckleBlender` have used the basic API calls to retrieve a dictionary of a Speckle resource, and done manual parsing and validation their own way.

Some time ago @AntoineDao introduced schema validation and data models using `pydantic`, which looks like it could really improve the flexibility and extensibility of the Python client.

This PR is a draft implementation of something like the element libraries that the .NET client uses: available schemas are stored in a `speckle.schemas` folder. When retrieving an object from the server, the available schemas are scanned for a match based on the incoming `type` field (Mesh, Brep, Line, Plane). The appropriate schema is applied.

This means that additional schemas could be added by users, while the Python client ships with the basic, necessary ones. 

I'm still getting familiarized with `pydantic` and the framework that @AntoineDao started, and I'm sure there is plenty of optimization, handling of inheritance, combined schemas, etc. that need to be done.

At the moment, this PR works in a simple test case. The old way still works fine side-by-side with this one, but eventually I want to change `SpeckleBlender` to this "new" way. The main change in existing code is the addition of a line in `base/resource.py` that scans for available schemas. The rest of the new stuff is separated.

Thoughts, comments, criticisms, alternatives welcome!