### PR TITLE
Add stream.baseProperties + cross-platform SpeckleSettings paths

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ mccabe==0.6.1
 more-itertools==7.0.0
 pluggy==0.11.0
 py==1.8.0
-pydantic==0.26
+pydantic==1.4
 requests==2.22.0
 six==1.12.0
 typed-ast==1.3.5

--- a/speckle/Cache.py
+++ b/speckle/Cache.py
@@ -30,7 +30,7 @@ class SpeckleCache():
     """
     initialized = False
 
-    def __init__(self, filepath=None):
+    def __init__(self, filepath=None, create=False):
         """Initialize cache object
 
         This creates a SpeckleCache object using either the default database 
@@ -42,13 +42,28 @@ class SpeckleCache():
             filepath {str} -- Optional database filepath (default: {None})
         """        
         if filepath is None:
-            self.db_path = os.path.join(os.getenv('LOCALAPPDATA'), os.path.join('SpeckleSettings', 'SpeckleCache.db'))
+
+            """
+            Get platform-dependent default SpeckleSettings directory
+            """
+            settings_dir = ""
+            if platform.system() == "Windows":
+                settings_dir = os.path.join(os.getenv('LOCALAPPDATA'), 'SpeckleSettings')
+            elif platform.system() == "Darwin":
+                settings_dir = os.path.join(os.getenv('HOME'), 'SpeckleSettings')
+            elif platform.system() == "Linux":
+                settings_dir = os.path.join(os.getenv('HOME'), 'SpeckleSettings')
+
+            self.db_path = os.path.join(settings_dir, 'SpeckleCache.db')
         else:
             self.db_path = filepath
 
         self.log(self.db_path)
 
         self.db_uri = 'file:{}?mode=rw'.format(pathname2url(self.db_path))
+
+        if create:
+            self.create_database(db_path)
 
         #if self.try_connect():
         #    self.initialized = True

--- a/speckle/resources/streams.py
+++ b/speckle/resources/streams.py
@@ -35,6 +35,10 @@ class Layer(BaseModel):
     def set_guid(cls, v):
         return v or str(uuid.uuid4())
 
+class StreamBaseProperties(BaseModel):
+    units: str = "Meters" # Set default units if none are found
+    tolerance: Optional[float]# = 1.0e-2
+    angleTolerance: Optional[float]# = 1.0e-2
 
 class Stream(ResourceBaseSchema):
     streamId: Optional[str]
@@ -46,6 +50,7 @@ class Stream(ResourceBaseSchema):
     layers: List[Layer] = []
     parent: Optional[str]
     children: List[str] = []
+    baseProperties: Optional[StreamBaseProperties]
 
 class Resource(ResourceBase):
     """API Access class for Streams


### PR DESCRIPTION
### Add stream.baseProperties

- Add `StreamBaseProperties` schema
- Add optional `baseProperties` property to `Stream` schema
- Solves #23 

### Cross-platform paths

- Add preliminary support for cross-platform `SpeckleSettings` path.

### Other

- Bumped required `pydantic` version to 1.4.
