### PR TITLE
build(typed-ast): upgrade to v1.4.1 for python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ py==1.8.0
 pydantic==1.4
 requests==2.22.0
 six==1.12.0
-typed-ast==1.3.5
+typed-ast==1.4.1
 urllib3==1.25.3
 wcwidth==0.1.7
 wrapt==1.11.1


### PR DESCRIPTION
heya! I was having issues installing after upgrading to 3.8 and came across [this issue](https://github.com/python/typed_ast/issues/126) in typed_ast which was addressed with a new version. upgrading to version 1.4.1 solved the problem for me. 

however, from the [repo](https://github.com/python/typed_ast) it looks like typed_ast now only support python 3.6 and up. is this acceptable for pyspeckle or is there a need to keep supporting earlier versions?