### PR TITLE
fix(objects): implement query for more commands, fix object dict() function, update examples in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,42 +25,102 @@ Here is how you initialise a client, authenticate and start speckling:
 ```python
 from speckle import SpeckleApiClient
 
+# Create a client using the appropriate server
 client = SpeckleApiClient('hestia.speckle.works')
 
+# Login with your details
 client.login(
     email='test@test.com',
     password='Speckle<3Python'
 )
 
+# Stream ID to get
 stream_id = 'HjenwS2s'
 
+# Get stream data using its ID
 stream = client.streams.get(stream_id)
 
+# Print the list of placeholder objects in the stream
 for object in stream.objects:
-  print(object.dict())
+  print(object)
 ```
 
 To get a list of all available streams and find a particular one by name:
 ```python
+
+# Fetch the list of all available streams
 streams = client.streams.list()
 name = "JetStream"
 
-try:
-    stream_id = [s for s in streams if s.name == name][0].streamId
-except:
-    print("Stream {} not found.".format(name))
-    return
+# Go through the list and find the stream by name
+stream = None
+for s in streams:
+    if s.name == name:
+        stream = s
+        break
+        
+# If the stream is found, fetch the full stream data, using an optional query dict 
+# to omit some data
+if stream:
+    stream_data = client.streams.get(stream.streamId, {'omit':['layers','comments']})
 ```
 
-To get all objects from a stream:
+To get object data from a stream:
 
 ```python
-for o in stream.objects:
-    try:
-        obj = client.objects.get(o.id)
-    except:
-        continue
-    print("Object {} is type {}.".format(obj.name, obj.type))
+stream = client.streams.get(streamId)
+
+# Fetch a single object using its placeholder ID
+object = client.objects.get(stream.objects[0].id)
+
+# Fetch the objects all at once using an optional query dict
+objects = client.objects.get_bulk([o.id for o in stream.objects], {'omit':'base64','displayValue'})
+
+# Print out some object info
+for o in objects:
+    print("Object {} is type {}".format(o.id, o.type)
+```
+
+To create some data and upload it to a stream:
+```python
+import speckle.schemas
+
+# Create some mesh data
+vertices = [[0,0,0],[1,0,0],[1,1,0], [0,1,0]]
+faces = [[0,1,2,3]]
+
+# Create a Speckle Mesh object
+sm = speckle.schemas.Mesh()
+
+# Add vertices
+for v in vertices:
+    sm.vertices.extend(v)
+
+# Add faces
+for f in faces:
+    if len(f) == 3: # if it is a triangle...
+        sm.faces.append(0)
+    elif len(f) == 4: # if it is a quad...
+        sm.faces.append(1)
+    sm.faces.extend(f)
+
+# Give it a nice name
+sm.name = "FancyMesh"
+
+# Create the object on the server and receive a list of
+# placeholders in return (with only one placeholder)
+placeholders = client.objects.create(sm)
+
+# Fetch the stream that we want to update
+stream = client.streams.get(streamId)
+
+# Set the stream object list to the created object or
+# extend it to add the object to the existing list
+stream.objects = placeholders
+#stream.objects.extend(placeholders)
+
+# Update the stream with the new data
+client.streams.update(stream.streamId, stream)
 ```
 
 Usage documentation can be found [here](https://pyspeckle.readthedocs.io/en/latest/).

--- a/speckle/Cache.py
+++ b/speckle/Cache.py
@@ -1,7 +1,7 @@
 import sqlite3, contextlib
 from urllib.request import pathname2url
 
-import os
+import os, platform
 
 """Speckle Cache documentation
 

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -7,6 +7,8 @@ import dataclasses
 from dataclasses import dataclass
 from datetime import datetime
 
+SCHEMAS = {}
+
 class ResourceBaseSchema(BaseModel):
     id: Optional[str]
     private: Optional[bool]

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -51,8 +51,8 @@ def clean_empty(d):
     if not isinstance(d, (dict, list)):
         return d
     if isinstance(d, list):
-        return [v for v in (clean_empty(v) for v in d) if v != None]
-    return {k: v for k, v in ((k, clean_empty(v)) for k, v in d.items()) if v != None}
+        return [v for v in (clean_empty(v) for v in d) if v is not None]
+    return {k: v for k, v in ((k, clean_empty(v)) for k, v in d.items()) if v is not None}
 
 class ResourceBase(object):
 
@@ -155,8 +155,7 @@ class ResourceBase(object):
         r = self._prep_request(method, path, comment, data, params)
         resp = self.s.send(r)
         if not resp.ok:
-            print(resp.text)
-            return None
+            return resp.status_code
         response_payload = resp.json()
         assert response_payload['success'] == True, json.dumps(response_payload)
 

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -99,7 +99,7 @@ class ResourceBase(object):
             url = self._comment_path + path
             if data:
                 dataclass_instance = self.comment_schema.parse_obj(data)
-                data = clean_empty(dataclass_instance.dict()) 
+                data = clean_empty(dataclass_instance.dict(by_alias=True))
         else:
             url = self._path + path
             if data:
@@ -109,13 +109,13 @@ class ResourceBase(object):
                         for d in data:
                             if isinstance(d, dict):
                                 dataclass_instance = self.schema.parse_obj(d)
-                                data_list.append(clean_empty(dataclass_instance.dict()))
+                                data_list.append(clean_empty(dataclass_instance.dict(by_alias=True)))
                             elif isinstance(d, str):
                                 data_list.append(d)
                         data = data_list
                 elif self.schema:
                     dataclass_instance = self.schema.parse_obj(data)
-                    data = clean_empty(dataclass_instance.dict())
+                    data = clean_empty(dataclass_instance.dict(by_alias=True))
 
         return self.s.prepare_request(Request(self.method_dict[method]['method'], url, json=data))
 

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -146,3 +146,30 @@ class ResourceBase(object):
             return self._parse_response(response_payload['resource'], comment, schema)
         else:
             return response_payload # Not sure what to do in this scenario or when it might occur
+
+    def make_query(self, query):
+        """Prepare a query string
+        
+        Arguments:
+            query {dict} -- A dictionary to specifiy which fields to retrieve, filters, limits, etc
+        
+        Returns:
+            str -- A query string to append to the request
+        """
+        if query:
+            query_string = '?'
+
+            for key, value in query.items():
+                query_string += key + '='
+                if isinstance(value, list):
+                    query_string += ','.join(value)
+                elif isinstance(value, str):
+                    query_string += value + '&'
+                else:
+                    raise 'query dict values must be list or string but key {} is of type {}'.format(key, type(value))
+
+            query_string = query_string[:-1] # Remove last '&' or '?' to be clean
+        else:
+            query_string = ''
+
+        return query_string

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -139,6 +139,9 @@ class ResourceBase(object):
     def make_request(self, method, path, data=None, comment=False, schema=None):
         r = self._prep_request(method, path, comment, data)
         resp = self.s.send(r)
+        if not resp.ok:
+            print(resp.text)
+            return None
         response_payload = resp.json()
         assert response_payload['success'] == True, json.dumps(response_payload)
 

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -154,8 +154,7 @@ class ResourceBase(object):
     def make_request(self, method, path, data=None, comment=False, schema=None, params=None):
         r = self._prep_request(method, path, comment, data, params)
         resp = self.s.send(r)
-        if not resp.ok:
-            return resp.status_code
+        resp.raise_for_status()
         response_payload = resp.json()
         assert response_payload['success'] == True, json.dumps(response_payload)
 

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -99,7 +99,7 @@ class ResourceBase(object):
             url = self._comment_path + path
             if data:
                 dataclass_instance = self.comment_schema.parse_obj(data)
-                data = clean_empty(dataclass_instance.dict(by_alias=True))
+                data = clean_empty(dataclass_instance.dict())
         else:
             url = self._path + path
             if data:
@@ -109,13 +109,13 @@ class ResourceBase(object):
                         for d in data:
                             if isinstance(d, dict):
                                 dataclass_instance = self.schema.parse_obj(d)
-                                data_list.append(clean_empty(dataclass_instance.dict(by_alias=True)))
+                                data_list.append(clean_empty(dataclass_instance.dict()))
                             elif isinstance(d, str):
                                 data_list.append(d)
                         data = data_list
                 elif self.schema:
                     dataclass_instance = self.schema.parse_obj(data)
-                    data = clean_empty(dataclass_instance.dict(by_alias=True))
+                    data = clean_empty(dataclass_instance.dict())
 
         return self.s.prepare_request(Request(self.method_dict[method]['method'], url, json=data))
 

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -103,7 +103,17 @@ class ResourceBase(object):
         else:
             url = self._path + path
             if data:
-                if self.schema:
+                if isinstance(data, list):
+                    data_list = []
+                    if self.schema:
+                        for d in data:
+                            if isinstance(d, dict):
+                                dataclass_instance = self.schema.parse_obj(d)
+                                data_list.append(clean_empty(dataclass_instance.dict()))
+                            elif isinstance(d, str):
+                                data_list.append(d)
+                        data = data_list
+                elif self.schema:
                     dataclass_instance = self.schema.parse_obj(data)
                     data = clean_empty(dataclass_instance.dict())
 
@@ -127,6 +137,9 @@ class ResourceBase(object):
         resp = self.s.send(r)
         response_payload = resp.json()
         assert response_payload['success'] == True, json.dumps(response_payload)
+
+        json.dumps(response_payload)
+
         if 'resources' in response_payload:
             return [self._parse_response(resource, comment, schema) for resource in response_payload['resources']]
         elif 'resource' in response_payload:

--- a/speckle/base/resource.py
+++ b/speckle/base/resource.py
@@ -99,7 +99,7 @@ class ResourceBase(object):
             url = self._comment_path + path
             if data:
                 dataclass_instance = self.comment_schema.parse_obj(data)
-                data = clean_empty(dataclass_instance.dict())
+                data = clean_empty(dataclass_instance.dict(by_alias=True))
         else:
             url = self._path + path
             if data:
@@ -109,13 +109,13 @@ class ResourceBase(object):
                         for d in data:
                             if isinstance(d, dict):
                                 dataclass_instance = self.schema.parse_obj(d)
-                                data_list.append(clean_empty(dataclass_instance.dict()))
+                                data_list.append(clean_empty(dataclass_instance.dict(by_alias=True)))
                             elif isinstance(d, str):
                                 data_list.append(d)
                         data = data_list
                 elif self.schema:
                     dataclass_instance = self.schema.parse_obj(data)
-                    data = clean_empty(dataclass_instance.dict())
+                    data = clean_empty(dataclass_instance.dict(by_alias=True))
 
         return self.s.prepare_request(Request(self.method_dict[method]['method'], url, json=data))
 

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -29,7 +29,7 @@ class SpeckleObject(ResourceBaseSchema):
 
         self.geometryHash = hashlib.md5(json_string.encode('utf-8')).hexdigest()
 
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
+        #self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(SpeckleObject, self).dict(include=include, by_alias=True, exclude=exclude)
     

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -131,7 +131,7 @@ class Resource(ResourceBase):
         """
         return self.make_request('comment_create', '/' + id, data, comment=True)
 
-    def get_bulk(self, object_ids, query):
+    def get_bulk(self, object_ids, query=None):
         """Retrieve and optionally update a list of Speckle objects
         
         Arguments:
@@ -141,18 +141,21 @@ class Resource(ResourceBase):
         Returns:
             list -- A list of SpeckleObjects
         """
-        query_string = '?'
+        if query:
+            query_string = '?'
 
-        for key, value in query.items:
-            query_string += key + '='
-            if isinstance(value, list):
-                query_string += ','.join(value)
-            elif isinstance(value, str):
-                query_string += value + '&'
-            else:
-                raise 'query dict values must be list or string but key {} is of type {}'.format(key, type(value))
+            for key, value in query.items():
+                query_string += key + '='
+                if isinstance(value, list):
+                    query_string += ','.join(value)
+                elif isinstance(value, str):
+                    query_string += value + '&'
+                else:
+                    raise 'query dict values must be list or string but key {} is of type {}'.format(key, type(value))
 
-        query_string = query_string[:-1] # Remove last '&' or '?' to be clean
+            query_string = query_string[:-1] # Remove last '&' or '?' to be clean
+        else:
+            query_string = ''
 
         return self.make_request('get_bulk', '/getbulk' + query_string, object_ids)
 

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -24,7 +24,7 @@ class SpeckleObject(ResourceBaseSchema):
     ancestors: Optional[List[str]]
 
     
-    def dict(self, include=None, exclude=None, by_alias=False, exclude_unset=False, exclude_defaults=False, exclude_none=False):
+    def dict(self, include=None, exclude=None, by_alias=True, exclude_unset=False, exclude_defaults=False, exclude_none=False):
         json_string = json.dumps(super(SpeckleObject, self).dict()['properties'])
 
         self.geometryHash = hashlib.md5(
@@ -32,7 +32,7 @@ class SpeckleObject(ResourceBaseSchema):
 
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
-        return super(SpeckleObject, self).dict(include=include, by_alias=True, exclude=exclude)
+        return super(SpeckleObject, self).dict(include=include, by_alias=by_alias, exclude=exclude)
     
 
 

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -29,7 +29,7 @@ class SpeckleObject(ResourceBaseSchema):
 
         self.geometryHash = hashlib.md5(json_string.encode('utf-8')).hexdigest()
 
-        #self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
+        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(SpeckleObject, self).dict(include=include, by_alias=True, exclude=exclude)
     
@@ -83,8 +83,8 @@ class Resource(ResourceBase):
         Returns:
             SpeckleObject -- The Speckle object
         """
-        query_string = self.make_query(query)
-        return self.make_request('get', '/' + id + query_string)
+        return self.make_request('get', '/' + id, params=query)
+
 
     def update(self, id, data):
         """Update a specific Speckle object
@@ -142,8 +142,7 @@ class Resource(ResourceBase):
         Returns:
             list -- A list of SpeckleObjects
         """
-        query_string = self.make_query(query)
-        return self.make_request('get_bulk', '/getbulk' + query_string, object_ids)
+        return self.make_request('get_bulk', '/getbulk', object_ids, params=query)
 
     def set_properties(self, id, data):
         return self.make_request('set_properties', '/' + id + '/properties', data)

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -32,7 +32,7 @@ class SpeckleObject(ResourceBaseSchema):
 
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
-        return super(SpeckleObject, self).dict(include=include, by_alias=by_alias, exclude=exclude)
+        return super(SpeckleObject, self).dict(include=include, by_alias=True, exclude=exclude)
     
 
 

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -27,10 +27,9 @@ class SpeckleObject(ResourceBaseSchema):
     def dict(self, include=None, exclude=None, by_alias=True, exclude_unset=False, exclude_defaults=False, exclude_none=False):
         json_string = json.dumps(super(SpeckleObject, self).dict()['properties'])
 
-        self.geometryHash = hashlib.md5(
-            json_string.encode('utf-8')).hexdigest()
+        self.geometryHash = hashlib.md5(json_string.encode('utf-8')).hexdigest()
 
-        self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
+        #self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
         return super(SpeckleObject, self).dict(include=include, by_alias=True, exclude=exclude)
     

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -32,7 +32,7 @@ class SpeckleObject(ResourceBaseSchema):
 
         self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
-        return super(SpeckleObject, self).dict(include=include, exclude=exclude)
+        return super(SpeckleObject, self).dict(include=include, by_alias=by_alias, exclude=exclude)
     
 
 

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -55,13 +55,14 @@ class Resource(ResourceBase):
            
         self.schema = SpeckleObject
 
-    def list(self):
+    def list(self, query=None):
         """List all Speckle objects
         
         Returns:
             list -- A list of Speckle object data class instances
         """
-        return self.make_request('list', '/')
+        query_string = self.make_query(query)        
+        return self.make_request('list', '/' + query_string)
 
     def create(self, data):
         """Create a Speckle object from a data dictionary
@@ -74,7 +75,7 @@ class Resource(ResourceBase):
         """
         return self.make_request('create', '/', data)
 
-    def get(self, id):
+    def get(self, id, query=None):
         """Get a specific Speckle object from the SpeckleServer
         
         Arguments:
@@ -83,7 +84,8 @@ class Resource(ResourceBase):
         Returns:
             SpeckleObject -- The Speckle object
         """
-        return self.make_request('get', '/' + id)
+        query_string = self.make_query(query)
+        return self.make_request('get', '/' + id + query_string)
 
     def update(self, id, data):
         """Update a specific Speckle object
@@ -141,22 +143,7 @@ class Resource(ResourceBase):
         Returns:
             list -- A list of SpeckleObjects
         """
-        if query:
-            query_string = '?'
-
-            for key, value in query.items():
-                query_string += key + '='
-                if isinstance(value, list):
-                    query_string += ','.join(value)
-                elif isinstance(value, str):
-                    query_string += value + '&'
-                else:
-                    raise 'query dict values must be list or string but key {} is of type {}'.format(key, type(value))
-
-            query_string = query_string[:-1] # Remove last '&' or '?' to be clean
-        else:
-            query_string = ''
-
+        query_string = self.make_query(query)
         return self.make_request('get_bulk', '/getbulk' + query_string, object_ids)
 
     def set_properties(self, id, data):

--- a/speckle/resources/streams.py
+++ b/speckle/resources/streams.py
@@ -50,7 +50,7 @@ class Stream(ResourceBaseSchema):
     layers: List[Layer] = []
     parent: Optional[str]
     children: List[str] = []
-    baseProperties: Optional[StreamBaseProperties]
+    baseProperties: Optional[StreamBaseProperties] = StreamBaseProperties()
 
 class Resource(ResourceBase):
     """API Access class for Streams

--- a/speckle/resources/streams.py
+++ b/speckle/resources/streams.py
@@ -83,8 +83,7 @@ class Resource(ResourceBase):
         Returns:
             list -- A list of Streams, without objects attached
         """
-        query_string = self.make_query(query)
-        return self.make_request('list', query_string)
+        return self.make_request('list', '/', params=query)
 
     def create(self, data):
         """Create a stream from a data dictionary
@@ -106,8 +105,7 @@ class Resource(ResourceBase):
         Returns:
             Stream -- The stream
         """
-        query_string = self.make_query(query)
-        return self.make_request('get', '/' + id + query_string)
+        return self.make_request('get', '/' + id, params=query)
 
     def update(self, id, data):
         """Update a specific stream

--- a/speckle/resources/streams.py
+++ b/speckle/resources/streams.py
@@ -77,13 +77,14 @@ class Resource(ResourceBase):
 
         self.schema = Stream
 
-    def list(self):
+    def list(self, query={'omit':'objects'}):
         """List all streams
         
         Returns:
             list -- A list of Streams, without objects attached
         """
-        return self.make_request('list', '?omit=objects')
+        query_string = self.make_query(query)
+        return self.make_request('list', query_string)
 
     def create(self, data):
         """Create a stream from a data dictionary
@@ -96,7 +97,7 @@ class Resource(ResourceBase):
         """
         return self.make_request('create', '/', data)
 
-    def get(self, id):
+    def get(self, id, query=None):
         """Get a specific stream from the SpeckleServer
         
         Arguments:
@@ -105,7 +106,8 @@ class Resource(ResourceBase):
         Returns:
             Stream -- The stream
         """
-        return self.make_request('get', '/' + id)
+        query_string = self.make_query(query)
+        return self.make_request('get', '/' + id + query_string)
 
     def update(self, id, data):
         """Update a specific stream

--- a/speckle/schemas/Arc.py
+++ b/speckle/schemas/Arc.py
@@ -11,9 +11,9 @@ NAME = 'arc'
 class Schema(SpeckleObject):
     type: Optional[str] = "Arc"
     name: Optional[str] = "SpeckleArc"
-    Radius: float = 0.0
-    StartAngle: float = 0.0
-    EndAngle: float = 0.0
-    AngleRadians: float = 0.0
-    Domain: Interval.Schema = Interval.Schema()
-    Plane: Plane = Plane.Schema()
+    radius: float = 0.0
+    startAngle: float = 0.0
+    endAngle: float = 0.0
+    angleRadians: float = 0.0
+    domain: Interval.Schema = Interval.Schema()
+    plane: Plane.Schema = Plane.Schema()

--- a/speckle/schemas/Interval.py
+++ b/speckle/schemas/Interval.py
@@ -9,5 +9,5 @@ NAME = 'interval'
 class Schema(ResourceBaseSchema):
     type: str = "Interval"
     name: Optional[str] = "SpeckleInterval"
-    Start: float = 0.0
-    End: float = 0.0
+    start: float = 0.0
+    end: float = 0.0

--- a/speckle/schemas/Line.py
+++ b/speckle/schemas/Line.py
@@ -12,5 +12,5 @@ NAME = 'line'
 class Schema(SpeckleObject):
     type: Optional[str] = "Line"
     name: Optional[str] = "SpeckleLine"
-    Value: List[float] = []
-    Domain: 'Interval' = Interval()
+    value: List[float] = []
+    domain: 'Interval' = Interval()

--- a/speckle/schemas/Plane.py
+++ b/speckle/schemas/Plane.py
@@ -11,7 +11,7 @@ NAME = 'plane'
 class Schema(SpeckleObject):
     type: Optional[str] = "Plane"
     name: Optional[str] = "SpecklePlane"
-    Origin: Point.Schema = Point.Schema(Value=[0,0,0])
-    Normal: Vector.Schema = Vector.Schema(Value=[0,0,1])
-    Xdir: Vector.Schema = Vector.Schema(Value=[1,0,0])
-    Ydir: Vector.Schema = Vector.Schema(Value=[0,1,0])
+    origin: Point.Schema = Point.Schema(Value=[0,0,0])
+    normal: Vector.Schema = Vector.Schema(Value=[0,0,1])
+    xdir: Vector.Schema = Vector.Schema(Value=[1,0,0])
+    ydir: Vector.Schema = Vector.Schema(Value=[0,1,0])

--- a/speckle/schemas/Point.py
+++ b/speckle/schemas/Point.py
@@ -11,4 +11,4 @@ NAME = 'point'
 class Schema(SpeckleObject):
     type: str = "Point"
     name: Optional[str] = "SpecklePoint"
-    Value: List[float] = [0,0,0]
+    value: List[float] = [0,0,0]

--- a/speckle/schemas/Polycurve.py
+++ b/speckle/schemas/Polycurve.py
@@ -11,6 +11,6 @@ NAME = 'polycurve'
 class Schema(SpeckleObject):
     type: Optional[str] = "Polycurve"
     name: Optional[str] = "SpecklePolycurve"
-    Segments: List[dict] = []
-    Domain: 'Interval' = Interval()
-    Closed: bool = False
+    segments: List[dict] = []
+    domain: 'Interval' = Interval()
+    closed: bool = False

--- a/speckle/schemas/Polyline.py
+++ b/speckle/schemas/Polyline.py
@@ -1,0 +1,16 @@
+import json
+import hashlib
+from pydantic import BaseModel, validator
+from typing import List, Optional
+from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
+
+NAME = 'polyline'
+
+class Schema(SpeckleObject):
+    type: str = "Polyline"
+    name: Optional[str] = "SpecklePolyline"
+    value: List[float] = []
+
+    #class Config:
+    #	fields={'Value':'value'}

--- a/speckle/schemas/Vector.py
+++ b/speckle/schemas/Vector.py
@@ -11,4 +11,4 @@ NAME = 'vector'
 class Schema(SpeckleObject):
     type: str = "Vector"
     name: Optional[str] = "SpeckleVector"
-    Value: List[float] = [0,0,1]
+    value: List[float] = [0,0,1]

--- a/speckle/schemas/__init__.py
+++ b/speckle/schemas/__init__.py
@@ -1,14 +1,14 @@
-from speckle.base.resource import ResourceBaseSchema
+from speckle.base.resource import ResourceBaseSchema, SCHEMAS
 from pathlib import Path
 import sys
 import inspect
 import pkgutil
 from importlib import import_module
 
-
 for (_, name, _) in pkgutil.iter_modules([Path(__file__).parent]):
 
     imported_module = import_module('.' + name, package=__name__)
     
     if hasattr(imported_module, 'Schema'):
+        SCHEMAS[name] = imported_module.Schema
         setattr(sys.modules[__name__], name, imported_module.Schema)

--- a/speckle/schemas/__init__.py
+++ b/speckle/schemas/__init__.py
@@ -1,9 +1,13 @@
 from speckle.base.resource import ResourceBaseSchema, SCHEMAS
+from speckle.resources.objects import SpeckleObject
+
 from pathlib import Path
 import sys
 import inspect
 import pkgutil
 from importlib import import_module
+
+setattr(sys.modules[__name__], "SpeckleObject", SpeckleObject)
 
 for (_, name, _) in pkgutil.iter_modules([Path(__file__).parent]):
 


### PR DESCRIPTION
A somewhat lengthy list of little fixes to get the dynamic schemas working better:

- `client.objects.get_bulk()` was throwing errors caused by attempting to parse the object schema when giving it a list of object IDs to retrieve. I've edited `ResourceBase._prep_request()` to catch it if it's a list or just a string before it tries to parse the schema, as well as code to make sure it parses the data dict using its own schema instead of the default SpeckleObject schema, if it is a schema. I'm sure this part could be cleaned up a little better, but it works.
- Added query input on more object and stream functions, and created `make_query()` in `base/resource.py` to make it consistent for all queries.
- Commented out the hash generation in `SpeckleObject.dict()` in `objects.py` as I believe this is handled by the server.
- Made sure that `SpeckleObject.dict()` always has `by_alias=True` otherwise it causes problems with parsing the `id`/`_id` fields.
- Made a global `SCHEMAS` dict to hold references to the schemas that are loaded on startup. This is just to prevent constantly searching the module directory whenever data is being parsed.

Overall, it is now a little bit easier and takes fewer lines of code to get up and running with the Python client :)
