### PR TITLE
feat(schemas): add Curve, Number, and String schemas

### DIFF
--- a/speckle/schemas/Curve.py
+++ b/speckle/schemas/Curve.py
@@ -1,0 +1,22 @@
+import json
+import hashlib
+from pydantic import BaseModel, validator
+from typing import List, Optional
+from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
+from speckle.schemas import Interval, Polyline
+
+NAME = 'curve'
+
+class Schema(SpeckleObject):
+    type: Optional[str] = "Curve"
+    name: Optional[str] = "SpecklePolycurve"
+    segments: List[dict] = []
+    domain: Interval.Schema = Interval.Schema()
+    degree: int = 0
+    rational: bool = True
+    periodic: bool = True
+    points: List[float] = []
+    weights: List[float] = []
+    knots: List[float] = []
+    displayValue: Optional[Polyline.Schema]

--- a/speckle/schemas/Line.py
+++ b/speckle/schemas/Line.py
@@ -12,5 +12,8 @@ NAME = 'line'
 class Schema(SpeckleObject):
     type: Optional[str] = "Line"
     name: Optional[str] = "SpeckleLine"
-    value: List[float] = []
-    domain: 'Interval' = Interval()
+    Value: List[float] = []
+    domain: Optional[Interval] = Interval()
+
+    class Config:
+    	case_sensitive = False

--- a/speckle/schemas/Number.py
+++ b/speckle/schemas/Number.py
@@ -1,0 +1,14 @@
+import json
+import hashlib
+from pydantic import BaseModel, validator
+from typing import List, Optional
+from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
+
+
+NAME = 'number'
+
+class Schema(SpeckleObject):
+    type: str = "Number"
+    name: Optional[str] = "SpeckleNumber"
+    value: float = 0.0

--- a/speckle/schemas/String.py
+++ b/speckle/schemas/String.py
@@ -1,0 +1,14 @@
+import json
+import hashlib
+from pydantic import BaseModel, validator
+from typing import List, Optional
+from speckle.base.resource import ResourceBaseSchema
+from speckle.resources.objects import SpeckleObject
+
+
+NAME = 'string'
+
+class Schema(SpeckleObject):
+    type: str = "String"
+    name: Optional[str] = "SpeckleString"
+    value: str = ""


### PR DESCRIPTION
Adding some more schemas:

- Curve to handle SpeckleCurve objects
- Number and String to be able to create and parse basic data types

Also updates Line.value to be Line.Value because of compatibility issues with some models (i.e. from Revit). Temporary fix.