### PR TITLE
fix(objects): prevent dropping of extra fields when parsing SpeckleObject

### DIFF
--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -31,7 +31,7 @@ class SpeckleObject(ResourceBaseSchema):
 
         #self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
-        return super(SpeckleObject, self).dict(include=include, by_alias=True, exclude=exclude)
+        return super(SpeckleObject, self).dict(include=include, by_alias=by_alias, exclude=exclude)
     
 
 

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -31,7 +31,7 @@ class SpeckleObject(ResourceBaseSchema):
 
         #self.hash = hashlib.md5('{}.{}'.format(self.type, json_string).encode('utf-8')).hexdigest()
 
-        return super(SpeckleObject, self).dict(include=include, by_alias=by_alias, exclude=exclude)
+        return super(SpeckleObject, self).dict(include=include, by_alias=True, exclude=exclude)
     
 
 

--- a/speckle/resources/objects.py
+++ b/speckle/resources/objects.py
@@ -33,7 +33,8 @@ class SpeckleObject(ResourceBaseSchema):
 
         return super(SpeckleObject, self).dict(include=include, by_alias=True, exclude=exclude)
     
-
+    class Config():
+        extra = 'allow'
 
 class Resource(ResourceBase):
     """API Access class for Speckle Objects


### PR DESCRIPTION
This allows extra fields to be kept when an object is parsed to the base `SpeckleObject` instead of stripping them. 