### PR TITLE
Add query kwarg to streams.list_objects

### DIFF
--- a/speckle/resources/streams.py
+++ b/speckle/resources/streams.py
@@ -183,7 +183,7 @@ class Resource(ResourceBase):
         """
         return self.make_request('diff', '/' + id + '/diff/' + other_id)
 
-    def list_objects(self, id):
+    def list_objects(self, id, query=None):
         """Return the list of objects in a stream
         
         Arguments:
@@ -192,7 +192,7 @@ class Resource(ResourceBase):
         Returns:
             list -- A list of Speckle objects
         """
-        return self.make_request('list_objects', '/' + id + '/objects', schema=SpeckleObject)
+        return self.make_request('list_objects', '/' + id + '/objects', schema=SpeckleObject, params=query)
 
     def list_clients(self, id):
         """Return the list of api clients connected to the stream


### PR DESCRIPTION
Add query capability to list_objects. Allows it to be used to efficiently query objects on the stream, similar to the query tester demonstrated here: https://speckle.systems/docs/developers/api-specs