### PR TITLE
Fix: error when config folder do not exist

### DIFF
--- a/speckle/Cache.py
+++ b/speckle/Cache.py
@@ -1,11 +1,12 @@
 import sqlite3, contextlib
 from urllib.request import pathname2url
 
-import os, platform
+import os
+import pathlib
 
 """Speckle Cache documentation
 
-The SpeckleCache class is used to manage user profiles and cached 
+The SpeckleCache class is used to manage user profiles and cached
 objects and streams.
 
 Example:
@@ -37,26 +38,26 @@ class SpeckleCache():
         location (%LOCALAPPDATA%/SpeckleSettings/SpeckleCache.db) or a user-
         specified database file.
 
-        
+
         Keyword Arguments:
             filepath {str} -- Optional database filepath (default: {None})
-        """        
+        """
         if filepath is None:
 
             """
             Get platform-dependent default SpeckleSettings directory
             """
-            settings_dir = ""
-            if platform.system() == "Windows":
-                settings_dir = os.path.join(os.getenv('LOCALAPPDATA'), 'SpeckleSettings')
-            elif platform.system() == "Darwin":
-                settings_dir = os.path.join(os.getenv('HOME'), 'SpeckleSettings')
-            elif platform.system() == "Linux":
-                settings_dir = os.path.join(os.getenv('HOME'), 'SpeckleSettings')
+            settings_dir = os.path.join(
+                os.environ.get('APPDATA') or
+                os.environ.get('XDG_CONFIG_HOME') or
+                os.path.join(os.environ['HOME'], '.config'),
+                "SpeckleSettings"
+            )
 
-            self.db_path = os.path.join(settings_dir, 'SpeckleCache.db')
-        else:
-            self.db_path = filepath
+            pathlib.Path(settings_dir).mkdir(parents=True, exist_ok=True)
+
+            filepath = os.path.join(settings_dir, 'SpeckleCache.db')
+        self.db_path = filepath
 
         self.log(self.db_path)
 


### PR DESCRIPTION
* Use conventionnal [XDG_Base_Directory](https://wiki.archlinux.org/index.php/XDG_Base_Directory) settings folder on Linux.
Ref: https://stackoverflow.com/a/14364249/4098083
Question : folder is called settings but class is called Cache. Is it cache or settings ?
If it is cache `XDG_CACHE_HOME` should be used instead of `XDG_CONFIG_HOME`.
* Use pathlib to create config folder if it do not exist.
Ref: https://stackoverflow.com/a/53222876/4098083

Fix https://github.com/speckleworks/SpeckleBlender/issues/16