### PR TITLE
Adds login_with_token method to allow directly specifying an API token

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,9 +12,6 @@ from speckle import SpeckleApiClient
 client = SpeckleApiClient('hestia.speckle.works')
 ```
 
-If you are already registered to the server and have logged in via one of the Speckle clients (Grasshopper, Revit, etc...), the SpeckleApiClient will automatically find your credentials
-and you can skip the next section.
-
 ## Registering and Logging in
 Before you can do anything with Speckle you need to register yourself to the server you are going to be using. If you have already registered then you can skip the first code section below and look at the one right after where we explain how to login.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,6 +12,9 @@ from speckle import SpeckleApiClient
 client = SpeckleApiClient('hestia.speckle.works')
 ```
 
+If you are already registered to the server and have logged in via one of the Speckle clients (Grasshopper, Revit, etc...), the SpeckleApiClient will automatically find your credentials
+and you can skip the next section.
+
 ## Registering and Logging in
 Before you can do anything with Speckle you need to register yourself to the server you are going to be using. If you have already registered then you can skip the first code section below and look at the one right after where we explain how to login.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,6 +38,15 @@ client.login(
 )
 ```
 
+If your server uses an alternate login mechanism (e.g. ActiveDirectory integration), you can use the `login_with_token` method, using the API token that you find in your user profile on 
+the Speckle server web interface:
+
+```python
+client.login_with_token(
+    token='JWT xwy334xdkfksldf....'
+)
+```
+
 ## Sending and Retrieving Things
 At the moment the api client takes dictionary payloads as data inputs (a `Speckle Object` for example) and returns data classes in most cases (essentially a class instance). If a data class is not returned then the object return is a dictionary. 
 

--- a/speckle/base/client.py
+++ b/speckle/base/client.py
@@ -118,6 +118,26 @@ class ClientBase():
             'Authorization': self.me['token'],
         })
 
+    def login_with_token(self, token):
+        """Login user to the speckle server using an API token
+
+        If your server uses an alternate login mechansim (e.g. ActiveDirectory), you can use this function to
+        store your API token in the client.
+
+        Arguments:
+            token {str} -- your Speckle API token (format 'JWT xxxxxxx', found on the Speckle web interface)"""
+        
+        if type(token) is not str:
+            raise ValueError("Token must be a string")
+
+        if (token[0:3] != 'JWT'):
+            raise ValueError("Toekn must begin with 'JWT'")
+        
+        self.s.headers.update({
+            'content-type': 'application/json',
+            'Authorization': token,
+        })
+    
     def websockets(self, stream_id, client_id=None, header=None,
                    on_open=None, on_message=None, on_error=None,
                    on_close=None, on_ping=None, on_pong=None,

--- a/speckle/base/client.py
+++ b/speckle/base/client.py
@@ -28,9 +28,6 @@ import requests
 from speckle import resources
 from websocket import WebSocketApp
 import urllib
-import sqlite3
-from os.path import exists, expandvars
-from re import match
 
 class ClientBase():
     """Base class for http speckle client
@@ -58,27 +55,6 @@ class ClientBase():
         self.me = None
         self.s = requests.Session()
         self.verbose = verbose
-
-        # Check if the current user is already registered to this server on this computer
-        try:
-            speckle_cache_path = expandvars(r'%LOCALAPPDATA%/SpeckleSettings/SpeckleCache.db')
-            if not exists(speckle_cache_path):
-                raise FileExistsError("No Speckle Cache present on this machine")
-            
-            with sqlite3.connect(speckle_cache_path) as conn:
-                c = conn.cursor()
-
-                ## The Speckle cache does not include the version indicator
-                server_key = match("(.*?api)", self.server).group(0)
-                c.execute("SELECT Email, Token FROM Account WHERE RestApi = ?", (server_key,))
-
-                (email, token) = c.fetchone()
-                self.me = {'email': email, 'token': token}
-                self.login_with_token(token)
-                self.me['email'] = email # self.me is created by login_with_token, so add the email after login_with_otken
-
-        except Exception as e: # this will trigger if there is no Speckle Cache or if the user is not registered
-            pass ## we tried, but since this is an automatic attempt (not a user request) we simply fail silently
 
     def register(self, email, password, company, name=None, surname=None):
         """Register a new user to the speckle server
@@ -148,7 +124,8 @@ class ClientBase():
         store your API token in the client.
 
         Arguments:
-            token {str} -- your Speckle API token (format 'JWT xxxxxxx', found on the Speckle web interface)"""
+            token {str} -- your Speckle API token (format 'JWT xxxxxxx', found on the Speckle web interface)
+        """
         
         if type(token) is not str:
             raise ValueError("Token must be a string")
@@ -161,8 +138,8 @@ class ClientBase():
             'Authorization': token,
         })
 
-        if self.me is None:
-            self.me = {}
+        full_profile = self.accounts.get_profile()
+        self.me = {k: full_profile.get(k, None) for k in ('id', 'email', 'name', 'surname', 'company', 'avatar', 'role', 'apitoken')}
         self.me['token'] = token
     
     def websockets(self, stream_id, client_id=None, header=None,


### PR DESCRIPTION
Hi @tsvilans ,

We have had a few people struggling to use PySpeckle with our internal servers, because we do not use the default username/password authentication. [See discussion here.](https://discourse.speckle.works/t/pyspeckle-authentication/1050/11)

To accomodate this, I have added a new method to the `ClientBase` class called `login_with_token`, and have updated the Quickstart docs to show how to use it.

Let me know if you'd like us to add tests for this. I had a quick look at the tests, but wasn't sure how I would add a test to cover this function.

cheers,
d