### PR TITLE
feat(client): add token property

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,6 +38,15 @@ client.login(
 )
 ```
 
+If your server uses an alternate login mechanism (e.g. ActiveDirectory integration), you can use the `login_with_token` method, using the API token that you find in your user profile on 
+the Speckle server web interface:
+
+```python
+client.login_with_token(
+    token='JWT xwy334xdkfksldf....'
+)
+```
+
 ## Sending and Retrieving Things
 At the moment the api client takes dictionary payloads as data inputs (a `Speckle Object` for example) and returns data classes in most cases (essentially a class instance). If a data class is not returned then the object return is a dictionary. 
 

--- a/speckle/base/client.py
+++ b/speckle/base/client.py
@@ -56,6 +56,14 @@ class ClientBase():
         self.s = requests.Session()
         self.verbose = verbose
 
+    @property
+    def token(self):
+        return self.s.headers.get("Authorization")
+
+    @token.setter
+    def token(self, value):
+        self.s.headers['Authorization'] = value
+
     def register(self, email, password, company, name=None, surname=None):
         """Register a new user to the speckle server
 

--- a/speckle/base/client.py
+++ b/speckle/base/client.py
@@ -56,7 +56,6 @@ class ClientBase():
         self.s = requests.Session()
         self.verbose = verbose
 
-
     def register(self, email, password, company, name=None, surname=None):
         """Register a new user to the speckle server
 
@@ -118,6 +117,31 @@ class ClientBase():
             'Authorization': self.me['token'],
         })
 
+    def login_with_token(self, token):
+        """Login user to the speckle server using an API token
+
+        If your server uses an alternate login mechansim (e.g. ActiveDirectory), you can use this function to
+        store your API token in the client.
+
+        Arguments:
+            token {str} -- your Speckle API token (format 'JWT xxxxxxx', found on the Speckle web interface)
+        """
+        
+        if type(token) is not str:
+            raise ValueError("Token must be a string")
+
+        if (token[0:3] != 'JWT'):
+            raise ValueError("Token must begin with 'JWT'")
+        
+        self.s.headers.update({
+            'content-type': 'application/json',
+            'Authorization': token,
+        })
+
+        full_profile = self.accounts.get_profile()
+        self.me = {k: full_profile.get(k, None) for k in ('id', 'email', 'name', 'surname', 'company', 'avatar', 'role', 'apitoken')}
+        self.me['token'] = token
+    
     def websockets(self, stream_id, client_id=None, header=None,
                    on_open=None, on_message=None, on_error=None,
                    on_close=None, on_ping=None, on_pong=None,

--- a/speckle/base/client.py
+++ b/speckle/base/client.py
@@ -56,6 +56,13 @@ class ClientBase():
         self.s = requests.Session()
         self.verbose = verbose
 
+    @property
+    def token(self):
+        return self.s.headers.get("Authorization")
+
+    @token.setter
+    def token(self, value):
+        self.s.headers['Authorization'] = value
 
     def register(self, email, password, company, name=None, surname=None):
         """Register a new user to the speckle server


### PR DESCRIPTION
From the discussion in #41, exposes the authentication token in `SpeckleApiClient` as a property, to make it easier / more intuitive to get/set.